### PR TITLE
Fix emission of map types for "type=object" fields.

### DIFF
--- a/cmd/gentypes/gentypes.go
+++ b/cmd/gentypes/gentypes.go
@@ -88,8 +88,15 @@ func parsePropertyType(propValue map[string]interface{}) string {
 			propItemsMap := propItems.(map[string]interface{})
 			return "[]" + parsePropertyType(propItemsMap)
 		case "object":
-			return "map[string]string"
-
+			// When the type of a property is "object", we'll emit a map with a string
+			// key and a value type that depends on the type of the
+			// additionalProperties field.
+			additionalProps, ok := propValue["additionalProperties"]
+			if !ok {
+				log.Fatal("missing additionalProperties field when type=object:", propValue)
+			}
+			valueType := parsePropertyType(additionalProps.(map[string]interface{}))
+			return fmt.Sprintf("map[string]%v", valueType)
 		default:
 			log.Fatal("unknown property type value", propType)
 		}

--- a/schematypes.go
+++ b/schematypes.go
@@ -209,11 +209,11 @@ type RunInTerminalRequest struct {
 }
 
 type RunInTerminalRequestArguments struct {
-	Args  []string          `json:"args"`
-	Cwd   string            `json:"cwd"`
-	Env   map[string]string `json:"env,omitempty"`
-	Kind  string            `json:"kind,omitempty"`
-	Title string            `json:"title,omitempty"`
+	Args  []string               `json:"args"`
+	Cwd   string                 `json:"cwd"`
+	Env   map[string]interface{} `json:"env,omitempty"`
+	Kind  string                 `json:"kind,omitempty"`
+	Title string                 `json:"title,omitempty"`
 }
 
 type RunInTerminalResponse struct {


### PR DESCRIPTION
The type of the key is string, but the type of the value depends on the
additionalProperties field.

Fixes #5