### PR TITLE
Make mock server concurrent

### DIFF
--- a/cmd/mockserver/server.go
+++ b/cmd/mockserver/server.go
@@ -288,9 +288,7 @@ func (ds *fakeDebugSession) doContinue() {
 		}
 	}()
 	// Keep potentially slow send out of the lock
-	if e != nil {
-		ds.send(e)
-	}
+	ds.send(e)
 }
 
 // -----------------------------------------------------------------------

--- a/cmd/mockserver/server_test.go
+++ b/cmd/mockserver/server_test.go
@@ -126,7 +126,7 @@ func client(t *testing.T, port string, wg *sync.WaitGroup) {
 	expectMessage(t, r, threadEvent)
 	expectMessage(t, r, configurationDoneResponse)
 
-	// Stop on preconfigured breakpoint
+	// Stop on preconfigured breakpoint & Continue
 
 	expectMessage(t, r, stoppedEvent)
 
@@ -139,13 +139,14 @@ func client(t *testing.T, port string, wg *sync.WaitGroup) {
 	dap.WriteBaseMessage(conn, scopesRequest)
 	expectMessage(t, r, scopesResponse)
 
+	// Processing of this request will be slow due to a fake delay.
+	// Send the next request right away and confirm that processing
+	// happens concurrently and the two responses are received
+	// out of order.
 	dap.WriteBaseMessage(conn, variablesRequest)
-	expectMessage(t, r, variablesResponse)
-
-	// Continue
-
 	dap.WriteBaseMessage(conn, continueRequest)
 	expectMessage(t, r, continueResponse)
+	expectMessage(t, r, variablesResponse)
 
 	// Shut down
 


### PR DESCRIPTION
The server now uses the following goroutines:
 - "main" goroutine accepts client connections one by one and handles them serially by reading and decoding incoming requests and dispatching each one to a new goroutine for further processing.
- per-request goroutines process each request as if letting fake debugger take over. They send events and responses via the sender goroutine.
- sender goroutine listens for messages to send and writes them to the client connection.