### PR TITLE
Harden protocol parsing against arbitrary Content-Length

### DIFF
--- a/io_test.go
+++ b/io_test.go
@@ -65,6 +65,8 @@ func Test_ReadBaseMessage(t *testing.T) {
 		{"Content-Length 1\r\n\r\nabc", nil, []byte("abc"), ErrHeaderNotContentLength},
 		{"Content-Length: 10\r\n\r\nabc", nil, []byte(""), io.ErrUnexpectedEOF},
 		{"Content-Length: 3\r\n\r\nabc", []byte("abc"), []byte(""), nil},
+		{"Content-Length: 4194305\r\n\r\nabc", nil, []byte("abc"), ErrHeaderContentTooLong},
+		{"Content-Length: 6506440440440\r\n\r\nabc", nil, []byte("abc"), ErrHeaderContentTooLong},
 	}
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {


### PR DESCRIPTION
I played with fuzzing go-dap and found that Content-Length's value is
not sanity-checked and we happily accept anything. Huge values cause the
program to crash or to hang, or just panic.

Also small restructure to vars/constants in io.go