### PR TITLE
Update debugProtocol.json schema to newest version: 1.41

### DIFF
--- a/cmd/gentypes/debugProtocol.json
+++ b/cmd/gentypes/debugProtocol.json
@@ -129,7 +129,7 @@
 		"CancelRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The 'cancel' request is used by the frontend to indicate that it is no longer interested in the result produced by a specific request issued earlier.\nThis request has a hint characteristic: a debug adapter can only be expected to make a 'best effort' in honouring this request but there are no guarantees.\nThe 'cancel' request may return an error if it could not cancel an operation but a frontend should refrain from presenting this error to end users.\nA frontend client should only call this request if the capability 'supportsCancelRequest' is true.\nThe request that got canceled still needs to send a response back.\nThis can either be a normal result ('success' attribute true) or an error response ('success' attribute false and the 'message' set to 'cancelled').\nReturning partial results from a cancelled request is possible but please note that a frontend client has no generic way for detecting that a response is partial or not.",
+				"description": "The 'cancel' request is used by the frontend in two situations:\n- to indicate that it is no longer interested in the result produced by a specific request issued earlier\n- to cancel a progress sequence. Clients should only call this request if the capability 'supportsCancelRequest' is true.\nThis request has a hint characteristic: a debug adapter can only be expected to make a 'best effort' in honouring this request but there are no guarantees.\nThe 'cancel' request may return an error if it could not cancel an operation but a frontend should refrain from presenting this error to end users.\nA frontend client should only call this request if the capability 'supportsCancelRequest' is true.\nThe request that got canceled still needs to send a response back. This can either be a normal result ('success' attribute true)\nor an error response ('success' attribute false and the 'message' set to 'cancelled').\nReturning partial results from a cancelled request is possible but please note that a frontend client has no generic way for detecting that a response is partial or not.\n The progress that got cancelled still needs to send a 'progressEnd' event back.\n A client should not assume that progress just got cancelled after sending the 'cancel' request.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -148,10 +148,13 @@
 			"properties": {
 				"requestId": {
 					"type": "integer",
-					"description": "The ID (attribute 'seq') of the request to cancel."
+					"description": "The ID (attribute 'seq') of the request to cancel. If missing no request is cancelled.\nBoth a 'requestId' and a 'progressId' can be specified in one request."
+				},
+				"progressId": {
+					"type": "string",
+					"description": "The ID (attribute 'progressId') of the progress to cancel. If missing no progress is cancelled.\nBoth a 'requestId' and a 'progressId' can be specified in one request."
 				}
-			},
-			"required": [ "id" ]
+			}
 		},
 		"CancelResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
@@ -164,7 +167,7 @@
 			"allOf": [ { "$ref": "#/definitions/Event" }, {
 				"type": "object",
 				"title": "Events",
-				"description": "This event indicates that the debug adapter is ready to accept configuration requests (e.g. SetBreakpointsRequest, SetExceptionBreakpointsRequest).\nA debug adapter is expected to send this event when it is ready to accept configuration requests (but not before the 'initialize' request has finished).\nThe sequence of events/requests is as follows:\n- adapters sends 'initialized' event (after the 'initialize' request has returned)\n- frontend sends zero or more 'setBreakpoints' requests\n- frontend sends one 'setFunctionBreakpoints' request\n- frontend sends a 'setExceptionBreakpoints' request if one or more 'exceptionBreakpointFilters' have been defined (or if 'supportsConfigurationDoneRequest' is not defined or false)\n- frontend sends other future configuration requests\n- frontend sends one 'configurationDone' request to indicate the end of the configuration.",
+				"description": "This event indicates that the debug adapter is ready to accept configuration requests (e.g. SetBreakpointsRequest, SetExceptionBreakpointsRequest).\nA debug adapter is expected to send this event when it is ready to accept configuration requests (but not before the 'initialize' request has finished).\nThe sequence of events/requests is as follows:\n- adapters sends 'initialized' event (after the 'initialize' request has returned)\n- frontend sends zero or more 'setBreakpoints' requests\n- frontend sends one 'setFunctionBreakpoints' request (if capability 'supportsFunctionBreakpoints' is true)\n- frontend sends a 'setExceptionBreakpoints' request if one or more 'exceptionBreakpointFilters' have been defined (or if 'supportsConfigurationDoneRequest' is not defined or false)\n- frontend sends other future configuration requests\n- frontend sends one 'configurationDone' request to indicate the end of the configuration.",
 				"properties": {
 					"event": {
 						"type": "string",
@@ -178,7 +181,7 @@
 		"StoppedEvent": {
 			"allOf": [ { "$ref": "#/definitions/Event" }, {
 				"type": "object",
-				"description": "The event indicates that the execution of the debuggee has stopped due to some condition.\nThis can be caused by a break point previously set, a stepping action has completed, by executing a debugger statement etc.",
+				"description": "The event indicates that the execution of the debuggee has stopped due to some condition.\nThis can be caused by a break point previously set, a stepping request has completed, by executing a debugger statement etc.",
 				"properties": {
 					"event": {
 						"type": "string",
@@ -190,7 +193,7 @@
 							"reason": {
 								"type": "string",
 								"description": "The reason for the event.\nFor backward compatibility this string is shown in the UI if the 'description' attribute is missing (but it must not be translated).",
-								"_enum": [ "step", "breakpoint", "exception", "pause", "entry", "goto", "function breakpoint", "data breakpoint" ]
+								"_enum": [ "step", "breakpoint", "exception", "pause", "entry", "goto", "function breakpoint", "data breakpoint", "instruction breakpoint" ]
 							},
 							"description": {
 								"type": "string",
@@ -344,6 +347,16 @@
 							"output": {
 								"type": "string",
 								"description": "The output to report."
+							},
+							"group": {
+								"type": "string",
+								"description": "Support for keeping an output log organized by grouping related messages.",
+								"enum": [ "start", "startCollapsed", "end" ],
+								"enumDescriptions": [
+									"Start a new group in expanded mode. Subsequent output events are members of the group and should be shown indented.\nThe 'output' attribute becomes the name of the group and is not indented.",
+									"Start a new group in collapsed mode. Subsequent output events are members of the group and should be shown indented (as soon as the group is expanded).\nThe 'output' attribute becomes the name of the group and is not indented.",
+									"End the current group and decreases the indentation of subsequent output events.\nA non empty 'output' attribute is shown as the unindented end of the group."
+								]
 							},
 							"variablesReference": {
 								"type": "integer",
@@ -533,11 +546,115 @@
 			}]
 		},
 
+		"ProgressStartEvent": {
+			"allOf": [ { "$ref": "#/definitions/Event" }, {
+				"type": "object",
+				"description": "The event signals that a long running operation is about to start and\nprovides additional information for the client to set up a corresponding progress and cancellation UI.\nThe client is free to delay the showing of the UI in order to reduce flicker.\nThis event should only be sent if the client has passed the value true for the 'supportsProgressReporting' capability of the 'initialize' request.",
+				"properties": {
+					"event": {
+						"type": "string",
+						"enum": [ "progressStart" ]
+					},
+					"body": {
+						"type": "object",
+						"properties": {
+							"progressId": {
+								"type": "string",
+								"description": "An ID that must be used in subsequent 'progressUpdate' and 'progressEnd' events to make them refer to the same progress reporting.\nIDs must be unique within a debug session."
+							},
+							"title": {
+								"type": "string",
+								"description": "Mandatory (short) title of the progress reporting. Shown in the UI to describe the long running operation."
+							},
+							"requestId": {
+								"type": "number",
+								"description": "The request ID that this progress report is related to. If specified a debug adapter is expected to emit\nprogress events for the long running request until the request has been either completed or cancelled.\nIf the request ID is omitted, the progress report is assumed to be related to some general activity of the debug adapter."
+							},
+							"cancellable": {
+								"type": "boolean",
+								"description": "If true, the request that reports progress may be canceled with a 'cancel' request.\nSo this property basically controls whether the client should use UX that supports cancellation.\nClients that don't support cancellation are allowed to ignore the setting."
+							},
+							"message": {
+								"type": "string",
+								"description": "Optional, more detailed progress message."
+							},
+							"percentage": {
+								"type": "number",
+								"description": "Optional progress percentage to display (value range: 0 to 100). If omitted no percentage will be shown."
+							}
+						},
+						"required": [ "progressId", "title" ]
+					}
+				},
+				"required": [ "event", "body" ]
+			}]
+		},
+
+		"ProgressUpdateEvent": {
+			"allOf": [ { "$ref": "#/definitions/Event" }, {
+				"type": "object",
+				"description": "The event signals that the progress reporting needs to updated with a new message and/or percentage.\nThe client does not have to update the UI immediately, but the clients needs to keep track of the message and/or percentage values.\nThis event should only be sent if the client has passed the value true for the 'supportsProgressReporting' capability of the 'initialize' request.",
+				"properties": {
+					"event": {
+						"type": "string",
+						"enum": [ "progressUpdate" ]
+					},
+					"body": {
+						"type": "object",
+						"properties": {
+							"progressId": {
+								"type": "string",
+								"description": "The ID that was introduced in the initial 'progressStart' event."
+							},
+							"message": {
+								"type": "string",
+								"description": "Optional, more detailed progress message. If omitted, the previous message (if any) is used."
+							},
+							"percentage": {
+								"type": "number",
+								"description": "Optional progress percentage to display (value range: 0 to 100). If omitted no percentage will be shown."
+							}
+						},
+						"required": [ "progressId" ]
+					}
+				},
+				"required": [ "event", "body" ]
+			}]
+		},
+
+		"ProgressEndEvent": {
+			"allOf": [ { "$ref": "#/definitions/Event" }, {
+				"type": "object",
+				"description": "The event signals the end of the progress reporting with an optional final message.\nThis event should only be sent if the client has passed the value true for the 'supportsProgressReporting' capability of the 'initialize' request.",
+				"properties": {
+					"event": {
+						"type": "string",
+						"enum": [ "progressEnd" ]
+					},
+					"body": {
+						"type": "object",
+						"properties": {
+							"progressId": {
+								"type": "string",
+								"description": "The ID that was introduced in the initial 'ProgressStartEvent'."
+							},
+							"message": {
+								"type": "string",
+								"description": "Optional, more detailed progress message. If omitted, the previous message (if any) is used."
+							}
+						},
+						"required": [ "progressId" ]
+					}
+				},
+				"required": [ "event", "body" ]
+			}]
+		},
+
 		"RunInTerminalRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
 				"title": "Reverse Requests",
-				"description": "This request is sent from the debug adapter to the client to run a command in a terminal. This is typically used to launch the debuggee in a terminal provided by the client.",
+				"description": "This optional request is sent from the debug adapter to the client to run a command in a terminal.\nThis is typically used to launch the debuggee in a terminal provided by the client.\nThis request should only be called if the client has passed the value true for the 'supportsRunInTerminalRequest' capability of the 'initialize' request.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -612,7 +729,7 @@
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
 				"title": "Requests",
-				"description": "The 'initialize' request is sent as the first request from the client to the debug adapter in order to configure it with client capabilities and to retrieve capabilities from the debug adapter.\nUntil the debug adapter has responded to with an 'initialize' response, the client must not send any additional requests or events to the debug adapter. In addition the debug adapter is not allowed to send any requests or events to the client until it has responded with an 'initialize' response.\nThe 'initialize' request may only be sent once.",
+				"description": "The 'initialize' request is sent as the first request from the client to the debug adapter\nin order to configure it with client capabilities and to retrieve capabilities from the debug adapter.\nUntil the debug adapter has responded to with an 'initialize' response, the client must not send any additional requests or events to the debug adapter.\nIn addition the debug adapter is not allowed to send any requests or events to the client until it has responded with an 'initialize' response.\nThe 'initialize' request may only be sent once.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -673,6 +790,10 @@
 				"supportsMemoryReferences": {
 					"type": "boolean",
 					"description": "Client supports memory references."
+				},
+				"supportsProgressReporting": {
+					"type": "boolean",
+					"description": "Client supports progress reporting."
 				}
 			},
 			"required": [ "adapterID" ]
@@ -693,7 +814,7 @@
 		"ConfigurationDoneRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The client of the debug protocol must send this request at the end of the sequence of configuration requests (which was started by the 'initialized' event).",
+				"description": "This optional request indicates that the client has finished initialization of the debug adapter.\nSo it is the last request in the sequence of configuration requests (which was started by the 'initialized' event).\nClients should only call this request if the capability 'supportsConfigurationDoneRequest' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -720,7 +841,7 @@
 		"LaunchRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The launch request is sent from the client to the debug adapter to start the debuggee with or without debugging (if 'noDebug' is true). Since launching is debugger/runtime specific, the arguments for this request are not part of this specification.",
+				"description": "This launch request is sent from the client to the debug adapter to start the debuggee with or without debugging (if 'noDebug' is true).\nSince launching is debugger/runtime specific, the arguments for this request are not part of this specification.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -757,7 +878,7 @@
 		"AttachRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The attach request is sent from the client to the debug adapter to attach to a debuggee that is already running. Since attaching is debugger/runtime specific, the arguments for this request are not part of this specification.",
+				"description": "The attach request is sent from the client to the debug adapter to attach to a debuggee that is already running.\nSince attaching is debugger/runtime specific, the arguments for this request are not part of this specification.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -790,7 +911,7 @@
 		"RestartRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Restarts a debug session. If the capability 'supportsRestartRequest' is missing or has the value false,\nthe client will implement 'restart' by terminating the debug adapter first and then launching it anew.\nA debug adapter can override this default behaviour by implementing a restart request\nand setting the capability 'supportsRestartRequest' to true.",
+				"description": "Restarts a debug session. Clients should only call this request if the capability 'supportsRestartRequest' is true.\nIf the capability is missing or has the value false, a typical client will emulate 'restart' by terminating the debug adapter first and then launching it anew.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -817,7 +938,7 @@
 		"DisconnectRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The 'disconnect' request is sent from the client to the debug adapter in order to stop debugging. It asks the debug adapter to disconnect from the debuggee and to terminate the debug adapter. If the debuggee has been started with the 'launch' request, the 'disconnect' request terminates the debuggee. If the 'attach' request was used to connect to the debuggee, 'disconnect' does not terminate the debuggee. This behavior can be controlled with the 'terminateDebuggee' argument (if supported by the debug adapter).",
+				"description": "The 'disconnect' request is sent from the client to the debug adapter in order to stop debugging.\nIt asks the debug adapter to disconnect from the debuggee and to terminate the debug adapter.\nIf the debuggee has been started with the 'launch' request, the 'disconnect' request terminates the debuggee.\nIf the 'attach' request was used to connect to the debuggee, 'disconnect' does not terminate the debuggee.\nThis behavior can be controlled with the 'terminateDebuggee' argument (if supported by the debug adapter).",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -840,7 +961,7 @@
 				},
 				"terminateDebuggee": {
 					"type": "boolean",
-					"description": "Indicates whether the debuggee should be terminated when the debugger is disconnected.\nIf unspecified, the debug adapter is free to do whatever it thinks is best.\nA client can only rely on this attribute being properly honored if a debug adapter returns true for the 'supportTerminateDebuggee' capability."
+					"description": "Indicates whether the debuggee should be terminated when the debugger is disconnected.\nIf unspecified, the debug adapter is free to do whatever it thinks is best.\nThe attribute is only honored by a debug adapter if the capability 'supportTerminateDebuggee' is true."
 				}
 			}
 		},
@@ -854,7 +975,7 @@
 		"TerminateRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The 'terminate' request is sent from the client to the debug adapter in order to give the debuggee a chance for terminating itself.",
+				"description": "The 'terminate' request is sent from the client to the debug adapter in order to give the debuggee a chance for terminating itself.\nClients should only call this request if the capability 'supportsTerminateRequest' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -887,7 +1008,7 @@
 		"BreakpointLocationsRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The 'breakpointLocations' request returns all possible locations for source breakpoints in a given range.",
+				"description": "The 'breakpointLocations' request returns all possible locations for source breakpoints in a given range.\nClients should only call this request if the capability 'supportsBreakpointLocationsRequest' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1009,7 +1130,7 @@
 								"items": {
 									"$ref": "#/definitions/Breakpoint"
 								},
-								"description": "Information about the breakpoints. The array elements are in the same order as the elements of the 'breakpoints' (or the deprecated 'lines') array in the arguments."
+								"description": "Information about the breakpoints.\nThe array elements are in the same order as the elements of the 'breakpoints' (or the deprecated 'lines') array in the arguments."
 							}
 						},
 						"required": [ "breakpoints" ]
@@ -1022,7 +1143,7 @@
 		"SetFunctionBreakpointsRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Replaces all existing function breakpoints with new function breakpoints.\nTo clear all function breakpoints, specify an empty array.\nWhen a function breakpoint is hit, a 'stopped' event (with reason 'function breakpoint') is generated.",
+				"description": "Replaces all existing function breakpoints with new function breakpoints.\nTo clear all function breakpoints, specify an empty array.\nWhen a function breakpoint is hit, a 'stopped' event (with reason 'function breakpoint') is generated.\nClients should only call this request if the capability 'supportsFunctionBreakpoints' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1075,7 +1196,7 @@
 		"SetExceptionBreakpointsRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request configures the debuggers response to thrown exceptions. If an exception is configured to break, a 'stopped' event is fired (with reason 'exception').",
+				"description": "The request configures the debuggers response to thrown exceptions.\nIf an exception is configured to break, a 'stopped' event is fired (with reason 'exception').\nClients should only call this request if the capability 'exceptionBreakpointFilters' returns one or more filters.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1104,7 +1225,7 @@
 					"items": {
 						"$ref": "#/definitions/ExceptionOptions"
 					},
-					"description": "Configuration options for selected exceptions."
+					"description": "Configuration options for selected exceptions.\nThe attribute is only honored by a debug adapter if the capability 'supportsExceptionOptions' is true."
 				}
 			},
 			"required": [ "filters" ]
@@ -1119,7 +1240,7 @@
 		"DataBreakpointInfoRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Obtains information on a possible data breakpoint that could be set on an expression or variable.",
+				"description": "Obtains information on a possible data breakpoint that could be set on an expression or variable.\nClients should only call this request if the capability 'supportsDataBreakpoints' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1142,7 +1263,7 @@
 				},
 				"name": {
 					"type": "string",
-					"description": "The name of the Variable's child to obtain data breakpoint information for. If variableReference isn’t provided, this can be an expression."
+					"description": "The name of the Variable's child to obtain data breakpoint information for.\nIf variableReference isn’t provided, this can be an expression."
 				}
 			},
 			"required": [ "name" ]
@@ -1185,7 +1306,7 @@
 		"SetDataBreakpointsRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Replaces all existing data breakpoints with new data breakpoints.\nTo clear all data breakpoints, specify an empty array.\nWhen a data breakpoint is hit, a 'stopped' event (with reason 'data breakpoint') is generated.",
+				"description": "Replaces all existing data breakpoints with new data breakpoints.\nTo clear all data breakpoints, specify an empty array.\nWhen a data breakpoint is hit, a 'stopped' event (with reason 'data breakpoint') is generated.\nClients should only call this request if the capability 'supportsDataBreakpoints' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1235,6 +1356,63 @@
 			}]
 		},
 
+		"SetInstructionBreakpointsRequest": {
+			"allOf": [
+				{ "$ref": "#/definitions/Request" },
+				{
+					"type": "object",
+					"description": "Replaces all existing instruction breakpoints. Typically, instruction breakpoints would be set from a diassembly window. \nTo clear all instruction breakpoints, specify an empty array.\nWhen an instruction breakpoint is hit, a 'stopped' event (with reason 'instruction breakpoint') is generated.\nClients should only call this request if the capability 'supportsInstructionBreakpoints' is true.",
+					"properties": {
+						"command": {
+						"type": "string",
+						"enum": [ "setInstructionBreakpoints" ]
+					},
+					"arguments": {
+						"$ref": "#/definitions/SetInstructionBreakpointsArguments"
+					}
+				},
+				"required": [ "command", "arguments" ]
+			}]
+		},
+		"SetInstructionBreakpointsArguments": {
+			"type": "object",
+			"description": "Arguments for 'setInstructionBreakpoints' request",
+			"properties": {
+				"breakpoints": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/InstructionBreakpoint"
+					},
+					"description": "The instruction references of the breakpoints"
+				}
+			},
+			"required": ["breakpoints"]
+		},
+		"SetInstructionBreakpointsResponse": {
+			"allOf": [
+				{ "$ref": "#/definitions/Response" },
+				{
+					"type": "object",
+					"description": "Response to 'setInstructionBreakpoints' request",
+					"properties": {
+						"body": {
+							"type": "object",
+							"properties": {
+								"breakpoints": {
+									"type": "array",
+									"items": {
+										"$ref": "#/definitions/Breakpoint"
+									},
+								"description": "Information about the breakpoints. The array elements correspond to the elements of the 'breakpoints' array."
+							}
+						},
+						"required": [ "breakpoints" ]
+					}
+				},
+				"required": [ "body" ]
+			}]
+		},
+
 		"ContinueRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
@@ -1257,7 +1435,7 @@
 			"properties": {
 				"threadId": {
 					"type": "integer",
-					"description": "Continue execution for the specified thread (if possible). If the backend cannot continue on a single thread but will continue on all threads, it should set the 'allThreadsContinued' attribute in the response to true."
+					"description": "Continue execution for the specified thread (if possible).\nIf the backend cannot continue on a single thread but will continue on all threads, it should set the 'allThreadsContinued' attribute in the response to true."
 				}
 			},
 			"required": [ "threadId" ]
@@ -1272,7 +1450,7 @@
 						"properties": {
 							"allThreadsContinued": {
 								"type": "boolean",
-								"description": "If true, the 'continue' request has ignored the specified thread and continued all threads instead. If this attribute is missing a value of 'true' is assumed for backward compatibility."
+								"description": "If true, the 'continue' request has ignored the specified thread and continued all threads instead.\nIf this attribute is missing a value of 'true' is assumed for backward compatibility."
 							}
 						}
 					}
@@ -1304,6 +1482,10 @@
 				"threadId": {
 					"type": "integer",
 					"description": "Execute 'next' for this thread."
+				},
+				"granularity": {
+					"$ref": "#/definitions/SteppingGranularity",
+					"description": "Optional granularity to step. If no granularity is specified, a granularity of 'statement' is assumed."
 				}
 			},
 			"required": [ "threadId" ]
@@ -1342,6 +1524,10 @@
 				"targetId": {
 					"type": "integer",
 					"description": "Optional id of the target to step into."
+				},
+				"granularity": {
+					"$ref": "#/definitions/SteppingGranularity",
+					"description": "Optional granularity to step. If no granularity is specified, a granularity of 'statement' is assumed."
 				}
 			},
 			"required": [ "threadId" ]
@@ -1376,6 +1562,10 @@
 				"threadId": {
 					"type": "integer",
 					"description": "Execute 'stepOut' for this thread."
+				},
+				"granularity": {
+					"$ref": "#/definitions/SteppingGranularity",
+					"description": "Optional granularity to step. If no granularity is specified, a granularity of 'statement' is assumed."
 				}
 			},
 			"required": [ "threadId" ]
@@ -1390,7 +1580,7 @@
 		"StepBackRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request starts the debuggee to run one step backwards.\nThe debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed. Clients should only call this request if the capability 'supportsStepBack' is true.",
+				"description": "The request starts the debuggee to run one step backwards.\nThe debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed.\nClients should only call this request if the capability 'supportsStepBack' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1410,6 +1600,10 @@
 				"threadId": {
 					"type": "integer",
 					"description": "Execute 'stepBack' for this thread."
+				},
+				"granularity": {
+					"$ref": "#/definitions/SteppingGranularity",
+					"description": "Optional granularity to step. If no granularity is specified, a granularity of 'statement' is assumed."
 				}
 			},
 			"required": [ "threadId" ]
@@ -1424,7 +1618,7 @@
 		"ReverseContinueRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request starts the debuggee to run backward. Clients should only call this request if the capability 'supportsStepBack' is true.",
+				"description": "The request starts the debuggee to run backward.\nClients should only call this request if the capability 'supportsStepBack' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1458,7 +1652,7 @@
 		"RestartFrameRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request restarts execution of the specified stackframe.\nThe debug adapter first sends the response and then a 'stopped' event (with reason 'restart') after the restart has completed.",
+				"description": "The request restarts execution of the specified stackframe.\nThe debug adapter first sends the response and then a 'stopped' event (with reason 'restart') after the restart has completed.\nClients should only call this request if the capability 'supportsRestartFrame' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1492,7 +1686,7 @@
 		"GotoRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request sets the location where the debuggee will continue to run.\nThis makes it possible to skip the execution of code or to executed code again.\nThe code between the current location and the goto target is not executed but skipped.\nThe debug adapter first sends the response and then a 'stopped' event with reason 'goto'.",
+				"description": "The request sets the location where the debuggee will continue to run.\nThis makes it possible to skip the execution of code or to executed code again.\nThe code between the current location and the goto target is not executed but skipped.\nThe debug adapter first sends the response and then a 'stopped' event with reason 'goto'.\nClients should only call this request if the capability 'supportsGotoTargetsRequest' is true (because only then goto targets exist that can be passed as arguments).",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1595,7 +1789,7 @@
 				},
 				"format": {
 					"$ref": "#/definitions/StackFrameFormat",
-					"description": "Specifies details on how to format the stack frames."
+					"description": "Specifies details on how to format the stack frames.\nThe attribute is only honored by a debug adapter if the capability 'supportsValueFormattingOptions' is true."
 				}
 			},
 			"required": [ "threadId" ]
@@ -1716,7 +1910,7 @@
 				},
 				"format": {
 					"$ref": "#/definitions/ValueFormat",
-					"description": "Specifies details on how to format the Variable values."
+					"description": "Specifies details on how to format the Variable values.\nThe attribute is only honored by a debug adapter if the capability 'supportsValueFormattingOptions' is true."
 				}
 			},
 			"required": [ "variablesReference" ]
@@ -1747,7 +1941,7 @@
 		"SetVariableRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Set the variable with the given name in the variable container to a new value.",
+				"description": "Set the variable with the given name in the variable container to a new value. Clients should only call this request if the capability 'supportsSetVariable' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1801,15 +1995,15 @@
 							},
 							"variablesReference": {
 								"type": "integer",
-								"description": "If variablesReference is > 0, the new value is structured and its children can be retrieved by passing variablesReference to the VariablesRequest. The value should be less than or equal to 2147483647 (2^31 - 1)."
+								"description": "If variablesReference is > 0, the new value is structured and its children can be retrieved by passing variablesReference to the VariablesRequest.\nThe value should be less than or equal to 2147483647 (2^31 - 1)."
 							},
 							"namedVariables": {
 								"type": "integer",
-								"description": "The number of named child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks. The value should be less than or equal to 2147483647 (2^31 - 1)."
+								"description": "The number of named child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31 - 1)."
 							},
 							"indexedVariables": {
 								"type": "integer",
-								"description": "The number of indexed child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks. The value should be less than or equal to 2147483647 (2^31 - 1)."
+								"description": "The number of indexed child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31 - 1)."
 							}
 						},
 						"required": [ "value" ]
@@ -1845,7 +2039,7 @@
 				},
 				"sourceReference": {
 					"type": "integer",
-					"description": "The reference to the source. This is the same as source.sourceReference. This is provided for backward compatibility since old backends do not understand the 'source' attribute."
+					"description": "The reference to the source. This is the same as source.sourceReference.\nThis is provided for backward compatibility since old backends do not understand the 'source' attribute."
 				}
 			},
 			"required": [ "sourceReference" ]
@@ -1913,7 +2107,7 @@
 		"TerminateThreadsRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request terminates the threads with the given ids.",
+				"description": "The request terminates the threads with the given ids.\nClients should only call this request if the capability 'supportsTerminateThreadsRequest' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1949,7 +2143,7 @@
 		"ModulesRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Modules can be retrieved from the debug adapter with the ModulesRequest which can either return all modules or a range of modules to support paging.",
+				"description": "Modules can be retrieved from the debug adapter with this request which can either return all modules or a range of modules to support paging.\nClients should only call this request if the capability 'supportsModulesRequest' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2006,7 +2200,7 @@
 		"LoadedSourcesRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Retrieves the set of all sources currently loaded by the debugged process.",
+				"description": "Retrieves the set of all sources currently loaded by the debugged process.\nClients should only call this request if the capability 'supportsLoadedSourcesRequest' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2076,17 +2270,18 @@
 				},
 				"context": {
 					"type": "string",
-					"_enum": [ "watch", "repl", "hover" ],
+					"_enum": [ "watch", "repl", "hover", "clipboard" ],
 					"enumDescriptions": [
 						"evaluate is run in a watch.",
 						"evaluate is run from REPL console.",
-						"evaluate is run from a data hover."
+						"evaluate is run from a data hover.",
+						"evaluate is run to generate the value that will be stored in the clipboard.\nThe attribute is only honored by a debug adapter if the capability 'supportsClipboardContext' is true."
 					],
 					"description": "The context in which the evaluate request is run."
 				},
 				"format": {
 					"$ref": "#/definitions/ValueFormat",
-					"description": "Specifies details on how to format the Evaluate result."
+					"description": "Specifies details on how to format the Evaluate result.\nThe attribute is only honored by a debug adapter if the capability 'supportsValueFormattingOptions' is true."
 				}
 			},
 			"required": [ "expression" ]
@@ -2105,7 +2300,7 @@
 							},
 							"type": {
 								"type": "string",
-								"description": "The optional type of the evaluate result."
+								"description": "The optional type of the evaluate result.\nThis attribute should only be returned by a debug adapter if the client has passed the value true for the 'supportsVariableType' capability of the 'initialize' request."
 							},
 							"presentationHint": {
 								"$ref": "#/definitions/VariablePresentationHint",
@@ -2113,19 +2308,19 @@
 							},
 							"variablesReference": {
 								"type": "integer",
-								"description": "If variablesReference is > 0, the evaluate result is structured and its children can be retrieved by passing variablesReference to the VariablesRequest. The value should be less than or equal to 2147483647 (2^31 - 1)."
+								"description": "If variablesReference is > 0, the evaluate result is structured and its children can be retrieved by passing variablesReference to the VariablesRequest.\nThe value should be less than or equal to 2147483647 (2^31 - 1)."
 							},
 							"namedVariables": {
 								"type": "integer",
-								"description": "The number of named child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks. The value should be less than or equal to 2147483647 (2^31 - 1)."
+								"description": "The number of named child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31 - 1)."
 							},
 							"indexedVariables": {
 								"type": "integer",
-								"description": "The number of indexed child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks. The value should be less than or equal to 2147483647 (2^31 - 1)."
+								"description": "The number of indexed child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31 - 1)."
 							},
 							"memoryReference": {
 								"type": "string",
-								"description": "Memory reference to a location appropriate for this result. For pointer type eval results, this is generally a reference to the memory address contained in the pointer."
+								"description": "Optional memory reference to a location appropriate for this result.\nFor pointer type eval results, this is generally a reference to the memory address contained in the pointer.\nThis attribute should be returned by a debug adapter if the client has passed the value true for the 'supportsMemoryReferences' capability of the 'initialize' request."
 							}
 						},
 						"required": [ "result", "variablesReference" ]
@@ -2138,7 +2333,7 @@
 		"SetExpressionRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Evaluates the given 'value' expression and assigns it to the 'expression' which must be a modifiable l-value.\nThe expressions have access to any variables and arguments that are in scope of the specified frame.",
+				"description": "Evaluates the given 'value' expression and assigns it to the 'expression' which must be a modifiable l-value.\nThe expressions have access to any variables and arguments that are in scope of the specified frame.\nClients should only call this request if the capability 'supportsSetExpression' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2188,7 +2383,7 @@
 							},
 							"type": {
 								"type": "string",
-								"description": "The optional type of the value."
+								"description": "The optional type of the value.\nThis attribute should only be returned by a debug adapter if the client has passed the value true for the 'supportsVariableType' capability of the 'initialize' request."
 							},
 							"presentationHint": {
 								"$ref": "#/definitions/VariablePresentationHint",
@@ -2196,15 +2391,15 @@
 							},
 							"variablesReference": {
 								"type": "integer",
-								"description": "If variablesReference is > 0, the value is structured and its children can be retrieved by passing variablesReference to the VariablesRequest. The value should be less than or equal to 2147483647 (2^31 - 1)."
+								"description": "If variablesReference is > 0, the value is structured and its children can be retrieved by passing variablesReference to the VariablesRequest.\nThe value should be less than or equal to 2147483647 (2^31 - 1)."
 							},
 							"namedVariables": {
 								"type": "integer",
-								"description": "The number of named child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks. The value should be less than or equal to 2147483647 (2^31 - 1)."
+								"description": "The number of named child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31 - 1)."
 							},
 							"indexedVariables": {
 								"type": "integer",
-								"description": "The number of indexed child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks. The value should be less than or equal to 2147483647 (2^31 - 1)."
+								"description": "The number of indexed child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31 - 1)."
 							}
 						},
 						"required": [ "value" ]
@@ -2217,7 +2412,7 @@
 		"StepInTargetsRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "This request retrieves the possible stepIn targets for the specified stack frame.\nThese targets can be used in the 'stepIn' request.\nThe StepInTargets may only be called if the 'supportsStepInTargetsRequest' capability exists and is true.",
+				"description": "This request retrieves the possible stepIn targets for the specified stack frame.\nThese targets can be used in the 'stepIn' request.\nThe StepInTargets may only be called if the 'supportsStepInTargetsRequest' capability exists and is true.\nClients should only call this request if the capability 'supportsStepInTargetsRequest' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2267,7 +2462,7 @@
 		"GotoTargetsRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "This request retrieves the possible goto targets for the specified source location.\nThese targets can be used in the 'goto' request.\nThe GotoTargets request may only be called if the 'supportsGotoTargetsRequest' capability exists and is true.",
+				"description": "This request retrieves the possible goto targets for the specified source location.\nThese targets can be used in the 'goto' request.\nClients should only call this request if the capability 'supportsGotoTargetsRequest' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2325,7 +2520,7 @@
 		"CompletionsRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Returns a list of possible completions for a given caret position and text.\nThe CompletionsRequest may only be called if the 'supportsCompletionsRequest' capability exists and is true.",
+				"description": "Returns a list of possible completions for a given caret position and text.\nClients should only call this request if the capability 'supportsCompletionsRequest' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2387,7 +2582,7 @@
 		"ExceptionInfoRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Retrieves the details of the exception that caused this event to be raised.",
+				"description": "Retrieves the details of the exception that caused this event to be raised.\nClients should only call this request if the capability 'supportsExceptionInfoRequest' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2446,7 +2641,7 @@
 		"ReadMemoryRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Reads bytes from memory at the provided location.",
+				"description": "Reads bytes from memory at the provided location.\nClients should only call this request if the capability 'supportsReadMemoryRequest' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2488,11 +2683,11 @@
 						"properties": {
 							"address": {
 								"type": "string",
-								"description": "The address of the first byte of data returned. Treated as a hex value if prefixed with '0x', or as a decimal value otherwise."
+								"description": "The address of the first byte of data returned.\nTreated as a hex value if prefixed with '0x', or as a decimal value otherwise."
 							},
 							"unreadableBytes": {
 								"type": "integer",
-								"description": "The number of unreadable bytes encountered after the last successfully read byte. This can be used to determine the number of bytes that must be skipped before a subsequent 'readMemory' request will succeed."
+								"description": "The number of unreadable bytes encountered after the last successfully read byte.\nThis can be used to determine the number of bytes that must be skipped before a subsequent 'readMemory' request will succeed."
 							},
 							"data": {
 								"type": "string",
@@ -2508,7 +2703,7 @@
 		"DisassembleRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Disassembles code stored at the provided location.",
+				"description": "Disassembles code stored at the provided location.\nClients should only call this request if the capability 'supportsDisassembleRequest' is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2539,7 +2734,7 @@
 				},
 				"instructionCount": {
 					"type": "integer",
-					"description": "Number of instructions to disassemble starting at the specified location and offset. An adapter must return exactly this number of instructions - any unavailable instructions should be replaced with an implementation-defined 'invalid instruction' value."
+					"description": "Number of instructions to disassemble starting at the specified location and offset.\nAn adapter must return exactly this number of instructions - any unavailable instructions should be replaced with an implementation-defined 'invalid instruction' value."
 				},
 				"resolveSymbols": {
 					"type": "boolean",
@@ -2714,6 +2909,18 @@
 				"supportsBreakpointLocationsRequest": {
 					"type": "boolean",
 					"description": "The debug adapter supports the 'breakpointLocations' request."
+				},
+				"supportsClipboardContext": {
+					"type": "boolean",
+					"description": "The debug adapter supports the 'clipboard' context value in the 'evaluate' request."
+				},
+				"supportsSteppingGranularity": {
+					"type": "boolean",
+					"description": "The debug adapter supports stepping granularities (argument 'granularity') for the stepping requests."
+				},
+				"supportsInstructionBreakpoints": {
+					"type": "boolean",
+					"description": "The debug adapter supports adding breakpoints based on instruction references."
 				}
 			}
 		},
@@ -2828,7 +3035,7 @@
 
 		"ColumnDescriptor": {
 			"type": "object",
-			"description": "A ColumnDescriptor specifies what module attribute to show in a column of the ModulesView, how to format it, and what the column's label should be.\nIt is only used if the underlying UI actually supports this level of customization.",
+			"description": "A ColumnDescriptor specifies what module attribute to show in a column of the ModulesView, how to format it,\nand what the column's label should be.\nIt is only used if the underlying UI actually supports this level of customization.",
 			"properties": {
 				"attributeName": {
 					"type": "string",
@@ -2887,23 +3094,23 @@
 
 		"Source": {
 			"type": "object",
-			"description": "A Source is a descriptor for source code. It is returned from the debug adapter as part of a StackFrame and it is used by clients when specifying breakpoints.",
+			"description": "A Source is a descriptor for source code.\nIt is returned from the debug adapter as part of a StackFrame and it is used by clients when specifying breakpoints.",
 			"properties": {
 				"name": {
 					"type": "string",
-					"description": "The short name of the source. Every source returned from the debug adapter has a name. When sending a source to the debug adapter this name is optional."
+					"description": "The short name of the source. Every source returned from the debug adapter has a name.\nWhen sending a source to the debug adapter this name is optional."
 				},
 				"path": {
 					"type": "string",
-					"description": "The path of the source to be shown in the UI. It is only used to locate and load the content of the source if no sourceReference is specified (or its value is 0)."
+					"description": "The path of the source to be shown in the UI.\nIt is only used to locate and load the content of the source if no sourceReference is specified (or its value is 0)."
 				},
 				"sourceReference": {
 					"type": "integer",
-					"description": "If sourceReference > 0 the contents of the source must be retrieved through the SourceRequest (even if a path is specified). A sourceReference is only valid for a session, so it must not be used to persist a source. The value should be less than or equal to 2147483647 (2^31 - 1)."
+					"description": "If sourceReference > 0 the contents of the source must be retrieved through the SourceRequest (even if a path is specified).\nA sourceReference is only valid for a session, so it must not be used to persist a source.\nThe value should be less than or equal to 2147483647 (2^31 - 1)."
 				},
 				"presentationHint": {
 					"type": "string",
-					"description": "An optional hint for how to present the source in the UI. A value of 'deemphasize' can be used to indicate that the source is not available or that it is skipped on stepping.",
+					"description": "An optional hint for how to present the source in the UI.\nA value of 'deemphasize' can be used to indicate that the source is not available or that it is skipped on stepping.",
 					"enum": [ "normal", "emphasize", "deemphasize" ]
 				},
 				"origin": {
@@ -2919,7 +3126,7 @@
 				},
 				"adapterData": {
 					"type": [ "array", "boolean", "integer", "null", "number", "object", "string" ],
-					"description": "Optional data that a debug adapter might want to loop through the client. The client should leave the data intact and persist it across sessions. The client should not interpret the data."
+					"description": "Optional data that a debug adapter might want to loop through the client.\nThe client should leave the data intact and persist it across sessions. The client should not interpret the data."
 				},
 				"checksums": {
 					"type": "array",
@@ -2937,7 +3144,7 @@
 			"properties": {
 				"id": {
 					"type": "integer",
-					"description": "An identifier for the stack frame. It must be unique across all threads. This id can be used to retrieve the scopes of the frame with the 'scopesRequest' or to restart the execution of a stackframe."
+					"description": "An identifier for the stack frame. It must be unique across all threads.\nThis id can be used to retrieve the scopes of the frame with the 'scopesRequest' or to restart the execution of a stackframe."
 				},
 				"name": {
 					"type": "string",
@@ -2974,7 +3181,7 @@
 				"presentationHint": {
 					"type": "string",
 					"enum": [ "normal", "label", "subtle" ],
-					"description": "An optional hint for how to present this frame in the UI. A value of 'label' can be used to indicate that the frame is an artificial frame that is used as a visual label or separator. A value of 'subtle' can be used to change the appearance of a frame in a 'subtle' way."
+					"description": "An optional hint for how to present this frame in the UI.\nA value of 'label' can be used to indicate that the frame is an artificial frame that is used as a visual label or separator. A value of 'subtle' can be used to change the appearance of a frame in a 'subtle' way."
 				}
 			},
 			"required": [ "id", "name", "line", "column" ]
@@ -3052,7 +3259,7 @@
 				},
 				"type": {
 					"type": "string",
-					"description": "The type of the variable's value. Typically shown in the UI when hovering over the value."
+					"description": "The type of the variable's value. Typically shown in the UI when hovering over the value.\nThis attribute should only be returned by a debug adapter if the client has passed the value true for the 'supportsVariableType' capability of the 'initialize' request."
 				},
 				"presentationHint": {
 					"$ref": "#/definitions/VariablePresentationHint",
@@ -3076,7 +3283,7 @@
 				},
 				"memoryReference": {
 					"type": "string",
-					"description": "Optional memory reference for the variable if the variable represents executable code, such as a function pointer."
+					"description": "Optional memory reference for the variable if the variable represents executable code, such as a function pointer.\nThis attribute is only required if the client has passed the value true for the 'supportsMemoryReferences' capability of the 'initialize' request."
 				}
 			},
 			"required": [ "name", "value", "variablesReference" ]
@@ -3100,7 +3307,7 @@
 						"Indicates that the object is an inner class.",
 						"Indicates that the object is an interface.",
 						"Indicates that the object is the most derived class.",
-						"Indicates that the object is virtual, that means it is a synthetic object introduced by the adapter for rendering purposes, e.g. an index range for large arrays.",
+						"Indicates that the object is virtual, that means it is a synthetic object introducedby the\nadapter for rendering purposes, e.g. an index range for large arrays.",
 						"Indicates that a data breakpoint is registered for the object."
 					]
 				},
@@ -3167,15 +3374,15 @@
 				},
 				"condition": {
 					"type": "string",
-					"description": "An optional expression for conditional breakpoints."
+					"description": "An optional expression for conditional breakpoints.\nIt is only honored by a debug adapter if the capability 'supportsConditionalBreakpoints' is true."
 				},
 				"hitCondition": {
 					"type": "string",
-					"description": "An optional expression that controls how many hits of the breakpoint are ignored. The backend is expected to interpret the expression as needed."
+					"description": "An optional expression that controls how many hits of the breakpoint are ignored.\nThe backend is expected to interpret the expression as needed.\nThe attribute is only honored by a debug adapter if the capability 'supportsHitConditionalBreakpoints' is true."
 				},
 				"logMessage": {
 					"type": "string",
-					"description": "If this attribute exists and is non-empty, the backend must not 'break' (stop) but log the message instead. Expressions within {} are interpolated."
+					"description": "If this attribute exists and is non-empty, the backend must not 'break' (stop)\nbut log the message instead. Expressions within {} are interpolated.\nThe attribute is only honored by a debug adapter if the capability 'supportsLogPoints' is true."
 				}
 			},
 			"required": [ "line" ]
@@ -3191,11 +3398,11 @@
 				},
 				"condition": {
 					"type": "string",
-					"description": "An optional expression for conditional breakpoints."
+					"description": "An optional expression for conditional breakpoints.\nIt is only honored by a debug adapter if the capability 'supportsConditionalBreakpoints' is true."
 				},
 				"hitCondition": {
 					"type": "string",
-					"description": "An optional expression that controls how many hits of the breakpoint are ignored. The backend is expected to interpret the expression as needed."
+					"description": "An optional expression that controls how many hits of the breakpoint are ignored.\nThe backend is expected to interpret the expression as needed.\nThe attribute is only honored by a debug adapter if the capability 'supportsHitConditionalBreakpoints' is true."
 				}
 			},
 			"required": [ "name" ]
@@ -3225,15 +3432,39 @@
 				},
 				"hitCondition": {
 					"type": "string",
-					"description": "An optional expression that controls how many hits of the breakpoint are ignored. The backend is expected to interpret the expression as needed."
+					"description": "An optional expression that controls how many hits of the breakpoint are ignored.\nThe backend is expected to interpret the expression as needed."
 				}
 			},
 			"required": [ "dataId" ]
 		},
 
+		"InstructionBreakpoint": {
+			"type": "object",
+			"description": "Properties of a breakpoint passed to the setInstructionBreakpoints request",
+			"properties": {
+				"instructionReference": {
+					"type": "string",
+					"description": "The instruction reference of the breakpoint.\nThis should be a memory or instruction pointer reference from an EvaluateResponse, Variable, StackFrame, GotoTarget, or Breakpoint."
+				},
+				"offset": {
+					"type": "integer",
+					"description": "An optional offset from the instruction reference.\nThis can be negative."
+				},
+				"condition": {
+					"type": "string",
+					"description": "An optional expression for conditional breakpoints.\nIt is only honored by a debug adapter if the capability 'supportsConditionalBreakpoints' is true."
+				},
+				"hitCondition": {
+					"type": "string",
+					"description": "An optional expression that controls how many hits of the breakpoint are ignored.\nThe backend is expected to interpret the expression as needed.\nThe attribute is only honored by a debug adapter if the capability 'supportsHitConditionalBreakpoints' is true."
+				}
+			},
+			"required": [ "instructionReference" ]
+		},
+
 		"Breakpoint": {
 			"type": "object",
-			"description": "Information about a Breakpoint created in setBreakpoints or setFunctionBreakpoints.",
+			"description": "Information about a Breakpoint created in setBreakpoints, setFunctionBreakpoints, setInstructionBreakpoints, or setDataBreakpoints.",
 			"properties": {
 				"id": {
 					"type": "integer",
@@ -3245,7 +3476,7 @@
 				},
 				"message": {
 					"type": "string",
-					"description": "An optional message about the state of the breakpoint. This is shown to the user and can be used to explain why a breakpoint could not be verified."
+					"description": "An optional message about the state of the breakpoint.\nThis is shown to the user and can be used to explain why a breakpoint could not be verified."
 				},
 				"source": {
 					"$ref": "#/definitions/Source",
@@ -3265,10 +3496,29 @@
 				},
 				"endColumn": {
 					"type": "integer",
-					"description": "An optional end column of the actual range covered by the breakpoint. If no end line is given, then the end column is assumed to be in the start line."
+					"description": "An optional end column of the actual range covered by the breakpoint.\nIf no end line is given, then the end column is assumed to be in the start line."
+				},
+				"instructionReference": {
+					"type": "string",
+					"description": "An optional memory reference to where the breakpoint is set."
+				},
+				"offset": {
+					"type": "integer",
+					"description": "An optional offset from the instruction reference.\nThis can be negative."
 				}
 			},
 			"required": [ "verified" ]
+		},
+
+		"SteppingGranularity": {
+			"type": "string",
+			"description": "The granularity of one 'step' in the stepping requests 'next', 'stepIn', 'stepOut', and 'stepBack'.",
+			"enum": [ "statement", "line", "instruction" ],
+			"enumDescriptions": [
+				"The step should allow the program to run until the current statement has finished executing.\nThe meaning of a statement is determined by the adapter and it may be considered equivalent to a line.\nFor example 'for(int i = 0; i < 10; i++) could be considered to have 3 statements 'int i = 0', 'i < 10', and 'i++'.",
+				"The step should allow the program to run until the current source line has executed.",
+				"The step should allow one instruction to execute (e.g. one x86 instruction)."
+			]
 		},
 
 		"StepInTarget": {
@@ -3350,6 +3600,14 @@
 				"length": {
 					"type": "integer",
 					"description": "This value determines how many characters are overwritten by the completion text.\nIf missing the value 0 is assumed which results in the completion text being inserted."
+				},
+				"selectionStart": {
+					"type": "integer",
+					"description": "Determines the start of the new selection after the text has been inserted (or replaced).\nThe start position must in the range 0 and length of the completion text.\nIf omitted the selection starts at the end of the completion text."
+				},
+				"selectionLength": {
+					"type": "integer",
+					"description": "Determines the length of the new selection after the text has been inserted (or replaced).\nThe selection can not extend beyond the bounds of the completion text.\nIf omitted the length is assumed to be 0."
 				}
 			},
 			"required": [ "label" ]
@@ -3440,7 +3698,7 @@
 					"items": {
 						"$ref": "#/definitions/ExceptionPathSegment"
 					},
-					"description": "A path that selects a single or multiple exceptions in a tree. If 'path' is missing, the whole tree is selected. By convention the first segment of the path is a category that is used to group exceptions in the UI."
+					"description": "A path that selects a single or multiple exceptions in a tree. If 'path' is missing, the whole tree is selected.\nBy convention the first segment of the path is a category that is used to group exceptions in the UI."
 				},
 				"breakMode": {
 					"$ref": "#/definitions/ExceptionBreakMode",
@@ -3458,7 +3716,7 @@
 
 		"ExceptionPathSegment": {
 			"type": "object",
-			"description": "An ExceptionPathSegment represents a segment in a path that is used to match leafs or nodes in a tree of exceptions. If a segment consists of more than one name, it matches the names provided if 'negate' is false or missing or it matches anything except the names provided if 'negate' is true.",
+			"description": "An ExceptionPathSegment represents a segment in a path that is used to match leafs or nodes in a tree of exceptions.\nIf a segment consists of more than one name, it matches the names provided if 'negate' is false or missing or\nit matches anything except the names provided if 'negate' is true.",
 			"properties": {
 				"negate": {
 					"type": "boolean",
@@ -3531,7 +3789,7 @@
 				},
 				"location": {
 					"$ref": "#/definitions/Source",
-					"description": "Source location that corresponds to this instruction, if any. Should always be set (if available) on the first instruction returned, but can be omitted afterwards if this instruction maps to the same source file as the previous instruction."
+					"description": "Source location that corresponds to this instruction, if any.\nShould always be set (if available) on the first instruction returned,\nbut can be omitted afterwards if this instruction maps to the same source file as the previous instruction."
 				},
 				"line": {
 					"type": "integer",

--- a/cmd/gentypes/gentypes.go
+++ b/cmd/gentypes/gentypes.go
@@ -75,6 +75,8 @@ func parsePropertyType(propValue map[string]interface{}) string {
 		switch propType {
 		case "string":
 			return "string"
+		case "number":
+			return "int"
 		case "integer":
 			return "int"
 		case "boolean":
@@ -97,7 +99,7 @@ func parsePropertyType(propValue map[string]interface{}) string {
 			valueType := parsePropertyType(additionalProps.(map[string]interface{}))
 			return fmt.Sprintf("map[string]%v", valueType)
 		default:
-			log.Fatal("unknown property type value", propType)
+			log.Fatalf("unknown property type value %v in %v", propType, propValue)
 		}
 
 	case []interface{}:

--- a/schematypes.go
+++ b/schematypes.go
@@ -69,13 +69,17 @@ type ErrorResponseBody struct {
 	Error ErrorMessage `json:"error,omitempty"`
 }
 
-// CancelRequest: The 'cancel' request is used by the frontend to indicate that it is no longer interested in the result produced by a specific request issued earlier.
+// CancelRequest: The 'cancel' request is used by the frontend in two situations:
+// - to indicate that it is no longer interested in the result produced by a specific request issued earlier
+// - to cancel a progress sequence. Clients should only call this request if the capability 'supportsCancelRequest' is true.
 // This request has a hint characteristic: a debug adapter can only be expected to make a 'best effort' in honouring this request but there are no guarantees.
 // The 'cancel' request may return an error if it could not cancel an operation but a frontend should refrain from presenting this error to end users.
 // A frontend client should only call this request if the capability 'supportsCancelRequest' is true.
-// The request that got canceled still needs to send a response back.
-// This can either be a normal result ('success' attribute true) or an error response ('success' attribute false and the 'message' set to 'cancelled').
+// The request that got canceled still needs to send a response back. This can either be a normal result ('success' attribute true)
+// or an error response ('success' attribute false and the 'message' set to 'cancelled').
 // Returning partial results from a cancelled request is possible but please note that a frontend client has no generic way for detecting that a response is partial or not.
+//  The progress that got cancelled still needs to send a 'progressEnd' event back.
+//  A client should not assume that progress just got cancelled after sending the 'cancel' request.
 type CancelRequest struct {
 	Request
 
@@ -84,7 +88,8 @@ type CancelRequest struct {
 
 // CancelArguments: Arguments for 'cancel' request.
 type CancelArguments struct {
-	RequestId int `json:"requestId,omitempty"`
+	RequestId  int    `json:"requestId,omitempty"`
+	ProgressId string `json:"progressId,omitempty"`
 }
 
 // CancelResponse: Response to 'cancel' request. This is just an acknowledgement, so no body field is required.
@@ -97,7 +102,7 @@ type CancelResponse struct {
 // The sequence of events/requests is as follows:
 // - adapters sends 'initialized' event (after the 'initialize' request has returned)
 // - frontend sends zero or more 'setBreakpoints' requests
-// - frontend sends one 'setFunctionBreakpoints' request
+// - frontend sends one 'setFunctionBreakpoints' request (if capability 'supportsFunctionBreakpoints' is true)
 // - frontend sends a 'setExceptionBreakpoints' request if one or more 'exceptionBreakpointFilters' have been defined (or if 'supportsConfigurationDoneRequest' is not defined or false)
 // - frontend sends other future configuration requests
 // - frontend sends one 'configurationDone' request to indicate the end of the configuration.
@@ -106,7 +111,7 @@ type InitializedEvent struct {
 }
 
 // StoppedEvent: The event indicates that the execution of the debuggee has stopped due to some condition.
-// This can be caused by a break point previously set, a stepping action has completed, by executing a debugger statement etc.
+// This can be caused by a break point previously set, a stepping request has completed, by executing a debugger statement etc.
 type StoppedEvent struct {
 	Event
 
@@ -180,6 +185,7 @@ type OutputEvent struct {
 type OutputEventBody struct {
 	Category           string      `json:"category,omitempty"`
 	Output             string      `json:"output"`
+	Group              string      `json:"group,omitempty"`
 	VariablesReference int         `json:"variablesReference,omitempty"`
 	Source             Source      `json:"source,omitempty"`
 	Line               int         `json:"line,omitempty"`
@@ -252,7 +258,56 @@ type CapabilitiesEventBody struct {
 	Capabilities Capabilities `json:"capabilities"`
 }
 
-// RunInTerminalRequest: This request is sent from the debug adapter to the client to run a command in a terminal. This is typically used to launch the debuggee in a terminal provided by the client.
+// ProgressStartEvent: The event signals that a long running operation is about to start and
+// provides additional information for the client to set up a corresponding progress and cancellation UI.
+// The client is free to delay the showing of the UI in order to reduce flicker.
+// This event should only be sent if the client has passed the value true for the 'supportsProgressReporting' capability of the 'initialize' request.
+type ProgressStartEvent struct {
+	Event
+
+	Body ProgressStartEventBody `json:"body"`
+}
+
+type ProgressStartEventBody struct {
+	ProgressId  string `json:"progressId"`
+	Title       string `json:"title"`
+	RequestId   int    `json:"requestId,omitempty"`
+	Cancellable bool   `json:"cancellable,omitempty"`
+	Message     string `json:"message,omitempty"`
+	Percentage  int    `json:"percentage,omitempty"`
+}
+
+// ProgressUpdateEvent: The event signals that the progress reporting needs to updated with a new message and/or percentage.
+// The client does not have to update the UI immediately, but the clients needs to keep track of the message and/or percentage values.
+// This event should only be sent if the client has passed the value true for the 'supportsProgressReporting' capability of the 'initialize' request.
+type ProgressUpdateEvent struct {
+	Event
+
+	Body ProgressUpdateEventBody `json:"body"`
+}
+
+type ProgressUpdateEventBody struct {
+	ProgressId string `json:"progressId"`
+	Message    string `json:"message,omitempty"`
+	Percentage int    `json:"percentage,omitempty"`
+}
+
+// ProgressEndEvent: The event signals the end of the progress reporting with an optional final message.
+// This event should only be sent if the client has passed the value true for the 'supportsProgressReporting' capability of the 'initialize' request.
+type ProgressEndEvent struct {
+	Event
+
+	Body ProgressEndEventBody `json:"body"`
+}
+
+type ProgressEndEventBody struct {
+	ProgressId string `json:"progressId"`
+	Message    string `json:"message,omitempty"`
+}
+
+// RunInTerminalRequest: This optional request is sent from the debug adapter to the client to run a command in a terminal.
+// This is typically used to launch the debuggee in a terminal provided by the client.
+// This request should only be called if the client has passed the value true for the 'supportsRunInTerminalRequest' capability of the 'initialize' request.
 type RunInTerminalRequest struct {
 	Request
 
@@ -280,8 +335,10 @@ type RunInTerminalResponseBody struct {
 	ShellProcessId int `json:"shellProcessId,omitempty"`
 }
 
-// InitializeRequest: The 'initialize' request is sent as the first request from the client to the debug adapter in order to configure it with client capabilities and to retrieve capabilities from the debug adapter.
-// Until the debug adapter has responded to with an 'initialize' response, the client must not send any additional requests or events to the debug adapter. In addition the debug adapter is not allowed to send any requests or events to the client until it has responded with an 'initialize' response.
+// InitializeRequest: The 'initialize' request is sent as the first request from the client to the debug adapter
+// in order to configure it with client capabilities and to retrieve capabilities from the debug adapter.
+// Until the debug adapter has responded to with an 'initialize' response, the client must not send any additional requests or events to the debug adapter.
+// In addition the debug adapter is not allowed to send any requests or events to the client until it has responded with an 'initialize' response.
 // The 'initialize' request may only be sent once.
 type InitializeRequest struct {
 	Request
@@ -302,6 +359,7 @@ type InitializeRequestArguments struct {
 	SupportsVariablePaging       bool   `json:"supportsVariablePaging,omitempty"`
 	SupportsRunInTerminalRequest bool   `json:"supportsRunInTerminalRequest,omitempty"`
 	SupportsMemoryReferences     bool   `json:"supportsMemoryReferences,omitempty"`
+	SupportsProgressReporting    bool   `json:"supportsProgressReporting,omitempty"`
 }
 
 // InitializeResponse: Response to 'initialize' request.
@@ -311,7 +369,9 @@ type InitializeResponse struct {
 	Body Capabilities `json:"body,omitempty"`
 }
 
-// ConfigurationDoneRequest: The client of the debug protocol must send this request at the end of the sequence of configuration requests (which was started by the 'initialized' event).
+// ConfigurationDoneRequest: This optional request indicates that the client has finished initialization of the debug adapter.
+// So it is the last request in the sequence of configuration requests (which was started by the 'initialized' event).
+// Clients should only call this request if the capability 'supportsConfigurationDoneRequest' is true.
 type ConfigurationDoneRequest struct {
 	Request
 
@@ -327,7 +387,8 @@ type ConfigurationDoneResponse struct {
 	Response
 }
 
-// LaunchRequest: The launch request is sent from the client to the debug adapter to start the debuggee with or without debugging (if 'noDebug' is true). Since launching is debugger/runtime specific, the arguments for this request are not part of this specification.
+// LaunchRequest: This launch request is sent from the client to the debug adapter to start the debuggee with or without debugging (if 'noDebug' is true).
+// Since launching is debugger/runtime specific, the arguments for this request are not part of this specification.
 type LaunchRequest struct {
 	Request
 
@@ -339,7 +400,8 @@ type LaunchResponse struct {
 	Response
 }
 
-// AttachRequest: The attach request is sent from the client to the debug adapter to attach to a debuggee that is already running. Since attaching is debugger/runtime specific, the arguments for this request are not part of this specification.
+// AttachRequest: The attach request is sent from the client to the debug adapter to attach to a debuggee that is already running.
+// Since attaching is debugger/runtime specific, the arguments for this request are not part of this specification.
 type AttachRequest struct {
 	Request
 
@@ -356,10 +418,8 @@ type AttachResponse struct {
 	Response
 }
 
-// RestartRequest: Restarts a debug session. If the capability 'supportsRestartRequest' is missing or has the value false,
-// the client will implement 'restart' by terminating the debug adapter first and then launching it anew.
-// A debug adapter can override this default behaviour by implementing a restart request
-// and setting the capability 'supportsRestartRequest' to true.
+// RestartRequest: Restarts a debug session. Clients should only call this request if the capability 'supportsRestartRequest' is true.
+// If the capability is missing or has the value false, a typical client will emulate 'restart' by terminating the debug adapter first and then launching it anew.
 type RestartRequest struct {
 	Request
 
@@ -375,7 +435,11 @@ type RestartResponse struct {
 	Response
 }
 
-// DisconnectRequest: The 'disconnect' request is sent from the client to the debug adapter in order to stop debugging. It asks the debug adapter to disconnect from the debuggee and to terminate the debug adapter. If the debuggee has been started with the 'launch' request, the 'disconnect' request terminates the debuggee. If the 'attach' request was used to connect to the debuggee, 'disconnect' does not terminate the debuggee. This behavior can be controlled with the 'terminateDebuggee' argument (if supported by the debug adapter).
+// DisconnectRequest: The 'disconnect' request is sent from the client to the debug adapter in order to stop debugging.
+// It asks the debug adapter to disconnect from the debuggee and to terminate the debug adapter.
+// If the debuggee has been started with the 'launch' request, the 'disconnect' request terminates the debuggee.
+// If the 'attach' request was used to connect to the debuggee, 'disconnect' does not terminate the debuggee.
+// This behavior can be controlled with the 'terminateDebuggee' argument (if supported by the debug adapter).
 type DisconnectRequest struct {
 	Request
 
@@ -394,6 +458,7 @@ type DisconnectResponse struct {
 }
 
 // TerminateRequest: The 'terminate' request is sent from the client to the debug adapter in order to give the debuggee a chance for terminating itself.
+// Clients should only call this request if the capability 'supportsTerminateRequest' is true.
 type TerminateRequest struct {
 	Request
 
@@ -411,6 +476,7 @@ type TerminateResponse struct {
 }
 
 // BreakpointLocationsRequest: The 'breakpointLocations' request returns all possible locations for source breakpoints in a given range.
+// Clients should only call this request if the capability 'supportsBreakpointLocationsRequest' is true.
 type BreakpointLocationsRequest struct {
 	Request
 
@@ -473,6 +539,7 @@ type SetBreakpointsResponseBody struct {
 // SetFunctionBreakpointsRequest: Replaces all existing function breakpoints with new function breakpoints.
 // To clear all function breakpoints, specify an empty array.
 // When a function breakpoint is hit, a 'stopped' event (with reason 'function breakpoint') is generated.
+// Clients should only call this request if the capability 'supportsFunctionBreakpoints' is true.
 type SetFunctionBreakpointsRequest struct {
 	Request
 
@@ -496,7 +563,9 @@ type SetFunctionBreakpointsResponseBody struct {
 	Breakpoints []Breakpoint `json:"breakpoints"`
 }
 
-// SetExceptionBreakpointsRequest: The request configures the debuggers response to thrown exceptions. If an exception is configured to break, a 'stopped' event is fired (with reason 'exception').
+// SetExceptionBreakpointsRequest: The request configures the debuggers response to thrown exceptions.
+// If an exception is configured to break, a 'stopped' event is fired (with reason 'exception').
+// Clients should only call this request if the capability 'exceptionBreakpointFilters' returns one or more filters.
 type SetExceptionBreakpointsRequest struct {
 	Request
 
@@ -515,6 +584,7 @@ type SetExceptionBreakpointsResponse struct {
 }
 
 // DataBreakpointInfoRequest: Obtains information on a possible data breakpoint that could be set on an expression or variable.
+// Clients should only call this request if the capability 'supportsDataBreakpoints' is true.
 type DataBreakpointInfoRequest struct {
 	Request
 
@@ -544,6 +614,7 @@ type DataBreakpointInfoResponseBody struct {
 // SetDataBreakpointsRequest: Replaces all existing data breakpoints with new data breakpoints.
 // To clear all data breakpoints, specify an empty array.
 // When a data breakpoint is hit, a 'stopped' event (with reason 'data breakpoint') is generated.
+// Clients should only call this request if the capability 'supportsDataBreakpoints' is true.
 type SetDataBreakpointsRequest struct {
 	Request
 
@@ -564,6 +635,32 @@ type SetDataBreakpointsResponse struct {
 }
 
 type SetDataBreakpointsResponseBody struct {
+	Breakpoints []Breakpoint `json:"breakpoints"`
+}
+
+// SetInstructionBreakpointsRequest: Replaces all existing instruction breakpoints. Typically, instruction breakpoints would be set from a diassembly window.
+// To clear all instruction breakpoints, specify an empty array.
+// When an instruction breakpoint is hit, a 'stopped' event (with reason 'instruction breakpoint') is generated.
+// Clients should only call this request if the capability 'supportsInstructionBreakpoints' is true.
+type SetInstructionBreakpointsRequest struct {
+	Request
+
+	Arguments SetInstructionBreakpointsArguments `json:"arguments"`
+}
+
+// SetInstructionBreakpointsArguments: Arguments for 'setInstructionBreakpoints' request
+type SetInstructionBreakpointsArguments struct {
+	Breakpoints []InstructionBreakpoint `json:"breakpoints"`
+}
+
+// SetInstructionBreakpointsResponse: Response to 'setInstructionBreakpoints' request
+type SetInstructionBreakpointsResponse struct {
+	Response
+
+	Body SetInstructionBreakpointsResponseBody `json:"body"`
+}
+
+type SetInstructionBreakpointsResponseBody struct {
 	Breakpoints []Breakpoint `json:"breakpoints"`
 }
 
@@ -600,7 +697,8 @@ type NextRequest struct {
 
 // NextArguments: Arguments for 'next' request.
 type NextArguments struct {
-	ThreadId int `json:"threadId"`
+	ThreadId    int                 `json:"threadId"`
+	Granularity SteppingGranularity `json:"granularity,omitempty"`
 }
 
 // NextResponse: Response to 'next' request. This is just an acknowledgement, so no body field is required.
@@ -622,8 +720,9 @@ type StepInRequest struct {
 
 // StepInArguments: Arguments for 'stepIn' request.
 type StepInArguments struct {
-	ThreadId int `json:"threadId"`
-	TargetId int `json:"targetId,omitempty"`
+	ThreadId    int                 `json:"threadId"`
+	TargetId    int                 `json:"targetId,omitempty"`
+	Granularity SteppingGranularity `json:"granularity,omitempty"`
 }
 
 // StepInResponse: Response to 'stepIn' request. This is just an acknowledgement, so no body field is required.
@@ -641,7 +740,8 @@ type StepOutRequest struct {
 
 // StepOutArguments: Arguments for 'stepOut' request.
 type StepOutArguments struct {
-	ThreadId int `json:"threadId"`
+	ThreadId    int                 `json:"threadId"`
+	Granularity SteppingGranularity `json:"granularity,omitempty"`
 }
 
 // StepOutResponse: Response to 'stepOut' request. This is just an acknowledgement, so no body field is required.
@@ -650,7 +750,8 @@ type StepOutResponse struct {
 }
 
 // StepBackRequest: The request starts the debuggee to run one step backwards.
-// The debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed. Clients should only call this request if the capability 'supportsStepBack' is true.
+// The debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed.
+// Clients should only call this request if the capability 'supportsStepBack' is true.
 type StepBackRequest struct {
 	Request
 
@@ -659,7 +760,8 @@ type StepBackRequest struct {
 
 // StepBackArguments: Arguments for 'stepBack' request.
 type StepBackArguments struct {
-	ThreadId int `json:"threadId"`
+	ThreadId    int                 `json:"threadId"`
+	Granularity SteppingGranularity `json:"granularity,omitempty"`
 }
 
 // StepBackResponse: Response to 'stepBack' request. This is just an acknowledgement, so no body field is required.
@@ -667,7 +769,8 @@ type StepBackResponse struct {
 	Response
 }
 
-// ReverseContinueRequest: The request starts the debuggee to run backward. Clients should only call this request if the capability 'supportsStepBack' is true.
+// ReverseContinueRequest: The request starts the debuggee to run backward.
+// Clients should only call this request if the capability 'supportsStepBack' is true.
 type ReverseContinueRequest struct {
 	Request
 
@@ -686,6 +789,7 @@ type ReverseContinueResponse struct {
 
 // RestartFrameRequest: The request restarts execution of the specified stackframe.
 // The debug adapter first sends the response and then a 'stopped' event (with reason 'restart') after the restart has completed.
+// Clients should only call this request if the capability 'supportsRestartFrame' is true.
 type RestartFrameRequest struct {
 	Request
 
@@ -706,6 +810,7 @@ type RestartFrameResponse struct {
 // This makes it possible to skip the execution of code or to executed code again.
 // The code between the current location and the goto target is not executed but skipped.
 // The debug adapter first sends the response and then a 'stopped' event with reason 'goto'.
+// Clients should only call this request if the capability 'supportsGotoTargetsRequest' is true (because only then goto targets exist that can be passed as arguments).
 type GotoRequest struct {
 	Request
 
@@ -819,7 +924,7 @@ type VariablesResponseBody struct {
 	Variables []Variable `json:"variables"`
 }
 
-// SetVariableRequest: Set the variable with the given name in the variable container to a new value.
+// SetVariableRequest: Set the variable with the given name in the variable container to a new value. Clients should only call this request if the capability 'supportsSetVariable' is true.
 type SetVariableRequest struct {
 	Request
 
@@ -891,6 +996,7 @@ type ThreadsResponseBody struct {
 }
 
 // TerminateThreadsRequest: The request terminates the threads with the given ids.
+// Clients should only call this request if the capability 'supportsTerminateThreadsRequest' is true.
 type TerminateThreadsRequest struct {
 	Request
 
@@ -907,7 +1013,8 @@ type TerminateThreadsResponse struct {
 	Response
 }
 
-// ModulesRequest: Modules can be retrieved from the debug adapter with the ModulesRequest which can either return all modules or a range of modules to support paging.
+// ModulesRequest: Modules can be retrieved from the debug adapter with this request which can either return all modules or a range of modules to support paging.
+// Clients should only call this request if the capability 'supportsModulesRequest' is true.
 type ModulesRequest struct {
 	Request
 
@@ -933,6 +1040,7 @@ type ModulesResponseBody struct {
 }
 
 // LoadedSourcesRequest: Retrieves the set of all sources currently loaded by the debugged process.
+// Clients should only call this request if the capability 'supportsLoadedSourcesRequest' is true.
 type LoadedSourcesRequest struct {
 	Request
 
@@ -989,6 +1097,7 @@ type EvaluateResponseBody struct {
 
 // SetExpressionRequest: Evaluates the given 'value' expression and assigns it to the 'expression' which must be a modifiable l-value.
 // The expressions have access to any variables and arguments that are in scope of the specified frame.
+// Clients should only call this request if the capability 'supportsSetExpression' is true.
 type SetExpressionRequest struct {
 	Request
 
@@ -1022,6 +1131,7 @@ type SetExpressionResponseBody struct {
 // StepInTargetsRequest: This request retrieves the possible stepIn targets for the specified stack frame.
 // These targets can be used in the 'stepIn' request.
 // The StepInTargets may only be called if the 'supportsStepInTargetsRequest' capability exists and is true.
+// Clients should only call this request if the capability 'supportsStepInTargetsRequest' is true.
 type StepInTargetsRequest struct {
 	Request
 
@@ -1046,7 +1156,7 @@ type StepInTargetsResponseBody struct {
 
 // GotoTargetsRequest: This request retrieves the possible goto targets for the specified source location.
 // These targets can be used in the 'goto' request.
-// The GotoTargets request may only be called if the 'supportsGotoTargetsRequest' capability exists and is true.
+// Clients should only call this request if the capability 'supportsGotoTargetsRequest' is true.
 type GotoTargetsRequest struct {
 	Request
 
@@ -1072,7 +1182,7 @@ type GotoTargetsResponseBody struct {
 }
 
 // CompletionsRequest: Returns a list of possible completions for a given caret position and text.
-// The CompletionsRequest may only be called if the 'supportsCompletionsRequest' capability exists and is true.
+// Clients should only call this request if the capability 'supportsCompletionsRequest' is true.
 type CompletionsRequest struct {
 	Request
 
@@ -1099,6 +1209,7 @@ type CompletionsResponseBody struct {
 }
 
 // ExceptionInfoRequest: Retrieves the details of the exception that caused this event to be raised.
+// Clients should only call this request if the capability 'supportsExceptionInfoRequest' is true.
 type ExceptionInfoRequest struct {
 	Request
 
@@ -1125,6 +1236,7 @@ type ExceptionInfoResponseBody struct {
 }
 
 // ReadMemoryRequest: Reads bytes from memory at the provided location.
+// Clients should only call this request if the capability 'supportsReadMemoryRequest' is true.
 type ReadMemoryRequest struct {
 	Request
 
@@ -1152,6 +1264,7 @@ type ReadMemoryResponseBody struct {
 }
 
 // DisassembleRequest: Disassembles code stored at the provided location.
+// Clients should only call this request if the capability 'supportsDisassembleRequest' is true.
 type DisassembleRequest struct {
 	Request
 
@@ -1212,6 +1325,9 @@ type Capabilities struct {
 	SupportsDisassembleRequest         bool                         `json:"supportsDisassembleRequest,omitempty"`
 	SupportsCancelRequest              bool                         `json:"supportsCancelRequest,omitempty"`
 	SupportsBreakpointLocationsRequest bool                         `json:"supportsBreakpointLocationsRequest,omitempty"`
+	SupportsClipboardContext           bool                         `json:"supportsClipboardContext,omitempty"`
+	SupportsSteppingGranularity        bool                         `json:"supportsSteppingGranularity,omitempty"`
+	SupportsInstructionBreakpoints     bool                         `json:"supportsInstructionBreakpoints,omitempty"`
 }
 
 // ExceptionBreakpointsFilter: An ExceptionBreakpointsFilter is shown in the UI as an option for configuring how exceptions are dealt with.
@@ -1253,7 +1369,8 @@ type Module struct {
 	AddressRange   string      `json:"addressRange,omitempty"`
 }
 
-// ColumnDescriptor: A ColumnDescriptor specifies what module attribute to show in a column of the ModulesView, how to format it, and what the column's label should be.
+// ColumnDescriptor: A ColumnDescriptor specifies what module attribute to show in a column of the ModulesView, how to format it,
+// and what the column's label should be.
 // It is only used if the underlying UI actually supports this level of customization.
 type ColumnDescriptor struct {
 	AttributeName string `json:"attributeName"`
@@ -1275,7 +1392,8 @@ type Thread struct {
 	Name string `json:"name"`
 }
 
-// Source: A Source is a descriptor for source code. It is returned from the debug adapter as part of a StackFrame and it is used by clients when specifying breakpoints.
+// Source: A Source is a descriptor for source code.
+// It is returned from the debug adapter as part of a StackFrame and it is used by clients when specifying breakpoints.
 type Source struct {
 	Name             string      `json:"name,omitempty"`
 	Path             string      `json:"path,omitempty"`
@@ -1376,17 +1494,30 @@ type DataBreakpoint struct {
 	HitCondition string                   `json:"hitCondition,omitempty"`
 }
 
-// Breakpoint: Information about a Breakpoint created in setBreakpoints or setFunctionBreakpoints.
-type Breakpoint struct {
-	Id        int    `json:"id,omitempty"`
-	Verified  bool   `json:"verified"`
-	Message   string `json:"message,omitempty"`
-	Source    Source `json:"source,omitempty"`
-	Line      int    `json:"line,omitempty"`
-	Column    int    `json:"column,omitempty"`
-	EndLine   int    `json:"endLine,omitempty"`
-	EndColumn int    `json:"endColumn,omitempty"`
+// InstructionBreakpoint: Properties of a breakpoint passed to the setInstructionBreakpoints request
+type InstructionBreakpoint struct {
+	InstructionReference string `json:"instructionReference"`
+	Offset               int    `json:"offset,omitempty"`
+	Condition            string `json:"condition,omitempty"`
+	HitCondition         string `json:"hitCondition,omitempty"`
 }
+
+// Breakpoint: Information about a Breakpoint created in setBreakpoints, setFunctionBreakpoints, setInstructionBreakpoints, or setDataBreakpoints.
+type Breakpoint struct {
+	Id                   int    `json:"id,omitempty"`
+	Verified             bool   `json:"verified"`
+	Message              string `json:"message,omitempty"`
+	Source               Source `json:"source,omitempty"`
+	Line                 int    `json:"line,omitempty"`
+	Column               int    `json:"column,omitempty"`
+	EndLine              int    `json:"endLine,omitempty"`
+	EndColumn            int    `json:"endColumn,omitempty"`
+	InstructionReference string `json:"instructionReference,omitempty"`
+	Offset               int    `json:"offset,omitempty"`
+}
+
+// SteppingGranularity: The granularity of one 'step' in the stepping requests 'next', 'stepIn', 'stepOut', and 'stepBack'.
+type SteppingGranularity string
 
 // StepInTarget: A StepInTarget can be used in the 'stepIn' request and determines into which single target the stepIn request should step.
 type StepInTarget struct {
@@ -1408,12 +1539,14 @@ type GotoTarget struct {
 
 // CompletionItem: CompletionItems are the suggestions returned from the CompletionsRequest.
 type CompletionItem struct {
-	Label    string             `json:"label"`
-	Text     string             `json:"text,omitempty"`
-	SortText string             `json:"sortText,omitempty"`
-	Type     CompletionItemType `json:"type,omitempty"`
-	Start    int                `json:"start,omitempty"`
-	Length   int                `json:"length,omitempty"`
+	Label           string             `json:"label"`
+	Text            string             `json:"text,omitempty"`
+	SortText        string             `json:"sortText,omitempty"`
+	Type            CompletionItemType `json:"type,omitempty"`
+	Start           int                `json:"start,omitempty"`
+	Length          int                `json:"length,omitempty"`
+	SelectionStart  int                `json:"selectionStart,omitempty"`
+	SelectionLength int                `json:"selectionLength,omitempty"`
 }
 
 // CompletionItemType: Some predefined types for the CompletionItem. Please note that not all clients have specific icons for all of them.
@@ -1459,7 +1592,9 @@ type ExceptionOptions struct {
 // userUnhandled: breaks if the exception is not handled by user code.
 type ExceptionBreakMode string
 
-// ExceptionPathSegment: An ExceptionPathSegment represents a segment in a path that is used to match leafs or nodes in a tree of exceptions. If a segment consists of more than one name, it matches the names provided if 'negate' is false or missing or it matches anything except the names provided if 'negate' is true.
+// ExceptionPathSegment: An ExceptionPathSegment represents a segment in a path that is used to match leafs or nodes in a tree of exceptions.
+// If a segment consists of more than one name, it matches the names provided if 'negate' is false or missing or
+// it matches anything except the names provided if 'negate' is true.
 type ExceptionPathSegment struct {
 	Negate bool     `json:"negate,omitempty"`
 	Names  []string `json:"names"`
@@ -1488,101 +1623,106 @@ type DisassembledInstruction struct {
 	EndColumn        int    `json:"endColumn,omitempty"`
 }
 
-func (m *Request) GetSeq() int                         { return m.Seq }
-func (m *Event) GetSeq() int                           { return m.Seq }
-func (m *Response) GetSeq() int                        { return m.Seq }
-func (m *ErrorResponse) GetSeq() int                   { return m.Seq }
-func (m *CancelRequest) GetSeq() int                   { return m.Seq }
-func (m *CancelResponse) GetSeq() int                  { return m.Seq }
-func (m *InitializedEvent) GetSeq() int                { return m.Seq }
-func (m *StoppedEvent) GetSeq() int                    { return m.Seq }
-func (m *ContinuedEvent) GetSeq() int                  { return m.Seq }
-func (m *ExitedEvent) GetSeq() int                     { return m.Seq }
-func (m *TerminatedEvent) GetSeq() int                 { return m.Seq }
-func (m *ThreadEvent) GetSeq() int                     { return m.Seq }
-func (m *OutputEvent) GetSeq() int                     { return m.Seq }
-func (m *BreakpointEvent) GetSeq() int                 { return m.Seq }
-func (m *ModuleEvent) GetSeq() int                     { return m.Seq }
-func (m *LoadedSourceEvent) GetSeq() int               { return m.Seq }
-func (m *ProcessEvent) GetSeq() int                    { return m.Seq }
-func (m *CapabilitiesEvent) GetSeq() int               { return m.Seq }
-func (m *RunInTerminalRequest) GetSeq() int            { return m.Seq }
-func (m *RunInTerminalResponse) GetSeq() int           { return m.Seq }
-func (m *InitializeRequest) GetSeq() int               { return m.Seq }
-func (m *InitializeResponse) GetSeq() int              { return m.Seq }
-func (m *ConfigurationDoneRequest) GetSeq() int        { return m.Seq }
-func (m *ConfigurationDoneResponse) GetSeq() int       { return m.Seq }
-func (m *LaunchRequest) GetSeq() int                   { return m.Seq }
-func (m *LaunchResponse) GetSeq() int                  { return m.Seq }
-func (m *AttachRequest) GetSeq() int                   { return m.Seq }
-func (m *AttachResponse) GetSeq() int                  { return m.Seq }
-func (m *RestartRequest) GetSeq() int                  { return m.Seq }
-func (m *RestartResponse) GetSeq() int                 { return m.Seq }
-func (m *DisconnectRequest) GetSeq() int               { return m.Seq }
-func (m *DisconnectResponse) GetSeq() int              { return m.Seq }
-func (m *TerminateRequest) GetSeq() int                { return m.Seq }
-func (m *TerminateResponse) GetSeq() int               { return m.Seq }
-func (m *BreakpointLocationsRequest) GetSeq() int      { return m.Seq }
-func (m *BreakpointLocationsResponse) GetSeq() int     { return m.Seq }
-func (m *SetBreakpointsRequest) GetSeq() int           { return m.Seq }
-func (m *SetBreakpointsResponse) GetSeq() int          { return m.Seq }
-func (m *SetFunctionBreakpointsRequest) GetSeq() int   { return m.Seq }
-func (m *SetFunctionBreakpointsResponse) GetSeq() int  { return m.Seq }
-func (m *SetExceptionBreakpointsRequest) GetSeq() int  { return m.Seq }
-func (m *SetExceptionBreakpointsResponse) GetSeq() int { return m.Seq }
-func (m *DataBreakpointInfoRequest) GetSeq() int       { return m.Seq }
-func (m *DataBreakpointInfoResponse) GetSeq() int      { return m.Seq }
-func (m *SetDataBreakpointsRequest) GetSeq() int       { return m.Seq }
-func (m *SetDataBreakpointsResponse) GetSeq() int      { return m.Seq }
-func (m *ContinueRequest) GetSeq() int                 { return m.Seq }
-func (m *ContinueResponse) GetSeq() int                { return m.Seq }
-func (m *NextRequest) GetSeq() int                     { return m.Seq }
-func (m *NextResponse) GetSeq() int                    { return m.Seq }
-func (m *StepInRequest) GetSeq() int                   { return m.Seq }
-func (m *StepInResponse) GetSeq() int                  { return m.Seq }
-func (m *StepOutRequest) GetSeq() int                  { return m.Seq }
-func (m *StepOutResponse) GetSeq() int                 { return m.Seq }
-func (m *StepBackRequest) GetSeq() int                 { return m.Seq }
-func (m *StepBackResponse) GetSeq() int                { return m.Seq }
-func (m *ReverseContinueRequest) GetSeq() int          { return m.Seq }
-func (m *ReverseContinueResponse) GetSeq() int         { return m.Seq }
-func (m *RestartFrameRequest) GetSeq() int             { return m.Seq }
-func (m *RestartFrameResponse) GetSeq() int            { return m.Seq }
-func (m *GotoRequest) GetSeq() int                     { return m.Seq }
-func (m *GotoResponse) GetSeq() int                    { return m.Seq }
-func (m *PauseRequest) GetSeq() int                    { return m.Seq }
-func (m *PauseResponse) GetSeq() int                   { return m.Seq }
-func (m *StackTraceRequest) GetSeq() int               { return m.Seq }
-func (m *StackTraceResponse) GetSeq() int              { return m.Seq }
-func (m *ScopesRequest) GetSeq() int                   { return m.Seq }
-func (m *ScopesResponse) GetSeq() int                  { return m.Seq }
-func (m *VariablesRequest) GetSeq() int                { return m.Seq }
-func (m *VariablesResponse) GetSeq() int               { return m.Seq }
-func (m *SetVariableRequest) GetSeq() int              { return m.Seq }
-func (m *SetVariableResponse) GetSeq() int             { return m.Seq }
-func (m *SourceRequest) GetSeq() int                   { return m.Seq }
-func (m *SourceResponse) GetSeq() int                  { return m.Seq }
-func (m *ThreadsRequest) GetSeq() int                  { return m.Seq }
-func (m *ThreadsResponse) GetSeq() int                 { return m.Seq }
-func (m *TerminateThreadsRequest) GetSeq() int         { return m.Seq }
-func (m *TerminateThreadsResponse) GetSeq() int        { return m.Seq }
-func (m *ModulesRequest) GetSeq() int                  { return m.Seq }
-func (m *ModulesResponse) GetSeq() int                 { return m.Seq }
-func (m *LoadedSourcesRequest) GetSeq() int            { return m.Seq }
-func (m *LoadedSourcesResponse) GetSeq() int           { return m.Seq }
-func (m *EvaluateRequest) GetSeq() int                 { return m.Seq }
-func (m *EvaluateResponse) GetSeq() int                { return m.Seq }
-func (m *SetExpressionRequest) GetSeq() int            { return m.Seq }
-func (m *SetExpressionResponse) GetSeq() int           { return m.Seq }
-func (m *StepInTargetsRequest) GetSeq() int            { return m.Seq }
-func (m *StepInTargetsResponse) GetSeq() int           { return m.Seq }
-func (m *GotoTargetsRequest) GetSeq() int              { return m.Seq }
-func (m *GotoTargetsResponse) GetSeq() int             { return m.Seq }
-func (m *CompletionsRequest) GetSeq() int              { return m.Seq }
-func (m *CompletionsResponse) GetSeq() int             { return m.Seq }
-func (m *ExceptionInfoRequest) GetSeq() int            { return m.Seq }
-func (m *ExceptionInfoResponse) GetSeq() int           { return m.Seq }
-func (m *ReadMemoryRequest) GetSeq() int               { return m.Seq }
-func (m *ReadMemoryResponse) GetSeq() int              { return m.Seq }
-func (m *DisassembleRequest) GetSeq() int              { return m.Seq }
-func (m *DisassembleResponse) GetSeq() int             { return m.Seq }
+func (m *Request) GetSeq() int                           { return m.Seq }
+func (m *Event) GetSeq() int                             { return m.Seq }
+func (m *Response) GetSeq() int                          { return m.Seq }
+func (m *ErrorResponse) GetSeq() int                     { return m.Seq }
+func (m *CancelRequest) GetSeq() int                     { return m.Seq }
+func (m *CancelResponse) GetSeq() int                    { return m.Seq }
+func (m *InitializedEvent) GetSeq() int                  { return m.Seq }
+func (m *StoppedEvent) GetSeq() int                      { return m.Seq }
+func (m *ContinuedEvent) GetSeq() int                    { return m.Seq }
+func (m *ExitedEvent) GetSeq() int                       { return m.Seq }
+func (m *TerminatedEvent) GetSeq() int                   { return m.Seq }
+func (m *ThreadEvent) GetSeq() int                       { return m.Seq }
+func (m *OutputEvent) GetSeq() int                       { return m.Seq }
+func (m *BreakpointEvent) GetSeq() int                   { return m.Seq }
+func (m *ModuleEvent) GetSeq() int                       { return m.Seq }
+func (m *LoadedSourceEvent) GetSeq() int                 { return m.Seq }
+func (m *ProcessEvent) GetSeq() int                      { return m.Seq }
+func (m *CapabilitiesEvent) GetSeq() int                 { return m.Seq }
+func (m *ProgressStartEvent) GetSeq() int                { return m.Seq }
+func (m *ProgressUpdateEvent) GetSeq() int               { return m.Seq }
+func (m *ProgressEndEvent) GetSeq() int                  { return m.Seq }
+func (m *RunInTerminalRequest) GetSeq() int              { return m.Seq }
+func (m *RunInTerminalResponse) GetSeq() int             { return m.Seq }
+func (m *InitializeRequest) GetSeq() int                 { return m.Seq }
+func (m *InitializeResponse) GetSeq() int                { return m.Seq }
+func (m *ConfigurationDoneRequest) GetSeq() int          { return m.Seq }
+func (m *ConfigurationDoneResponse) GetSeq() int         { return m.Seq }
+func (m *LaunchRequest) GetSeq() int                     { return m.Seq }
+func (m *LaunchResponse) GetSeq() int                    { return m.Seq }
+func (m *AttachRequest) GetSeq() int                     { return m.Seq }
+func (m *AttachResponse) GetSeq() int                    { return m.Seq }
+func (m *RestartRequest) GetSeq() int                    { return m.Seq }
+func (m *RestartResponse) GetSeq() int                   { return m.Seq }
+func (m *DisconnectRequest) GetSeq() int                 { return m.Seq }
+func (m *DisconnectResponse) GetSeq() int                { return m.Seq }
+func (m *TerminateRequest) GetSeq() int                  { return m.Seq }
+func (m *TerminateResponse) GetSeq() int                 { return m.Seq }
+func (m *BreakpointLocationsRequest) GetSeq() int        { return m.Seq }
+func (m *BreakpointLocationsResponse) GetSeq() int       { return m.Seq }
+func (m *SetBreakpointsRequest) GetSeq() int             { return m.Seq }
+func (m *SetBreakpointsResponse) GetSeq() int            { return m.Seq }
+func (m *SetFunctionBreakpointsRequest) GetSeq() int     { return m.Seq }
+func (m *SetFunctionBreakpointsResponse) GetSeq() int    { return m.Seq }
+func (m *SetExceptionBreakpointsRequest) GetSeq() int    { return m.Seq }
+func (m *SetExceptionBreakpointsResponse) GetSeq() int   { return m.Seq }
+func (m *DataBreakpointInfoRequest) GetSeq() int         { return m.Seq }
+func (m *DataBreakpointInfoResponse) GetSeq() int        { return m.Seq }
+func (m *SetDataBreakpointsRequest) GetSeq() int         { return m.Seq }
+func (m *SetDataBreakpointsResponse) GetSeq() int        { return m.Seq }
+func (m *SetInstructionBreakpointsRequest) GetSeq() int  { return m.Seq }
+func (m *SetInstructionBreakpointsResponse) GetSeq() int { return m.Seq }
+func (m *ContinueRequest) GetSeq() int                   { return m.Seq }
+func (m *ContinueResponse) GetSeq() int                  { return m.Seq }
+func (m *NextRequest) GetSeq() int                       { return m.Seq }
+func (m *NextResponse) GetSeq() int                      { return m.Seq }
+func (m *StepInRequest) GetSeq() int                     { return m.Seq }
+func (m *StepInResponse) GetSeq() int                    { return m.Seq }
+func (m *StepOutRequest) GetSeq() int                    { return m.Seq }
+func (m *StepOutResponse) GetSeq() int                   { return m.Seq }
+func (m *StepBackRequest) GetSeq() int                   { return m.Seq }
+func (m *StepBackResponse) GetSeq() int                  { return m.Seq }
+func (m *ReverseContinueRequest) GetSeq() int            { return m.Seq }
+func (m *ReverseContinueResponse) GetSeq() int           { return m.Seq }
+func (m *RestartFrameRequest) GetSeq() int               { return m.Seq }
+func (m *RestartFrameResponse) GetSeq() int              { return m.Seq }
+func (m *GotoRequest) GetSeq() int                       { return m.Seq }
+func (m *GotoResponse) GetSeq() int                      { return m.Seq }
+func (m *PauseRequest) GetSeq() int                      { return m.Seq }
+func (m *PauseResponse) GetSeq() int                     { return m.Seq }
+func (m *StackTraceRequest) GetSeq() int                 { return m.Seq }
+func (m *StackTraceResponse) GetSeq() int                { return m.Seq }
+func (m *ScopesRequest) GetSeq() int                     { return m.Seq }
+func (m *ScopesResponse) GetSeq() int                    { return m.Seq }
+func (m *VariablesRequest) GetSeq() int                  { return m.Seq }
+func (m *VariablesResponse) GetSeq() int                 { return m.Seq }
+func (m *SetVariableRequest) GetSeq() int                { return m.Seq }
+func (m *SetVariableResponse) GetSeq() int               { return m.Seq }
+func (m *SourceRequest) GetSeq() int                     { return m.Seq }
+func (m *SourceResponse) GetSeq() int                    { return m.Seq }
+func (m *ThreadsRequest) GetSeq() int                    { return m.Seq }
+func (m *ThreadsResponse) GetSeq() int                   { return m.Seq }
+func (m *TerminateThreadsRequest) GetSeq() int           { return m.Seq }
+func (m *TerminateThreadsResponse) GetSeq() int          { return m.Seq }
+func (m *ModulesRequest) GetSeq() int                    { return m.Seq }
+func (m *ModulesResponse) GetSeq() int                   { return m.Seq }
+func (m *LoadedSourcesRequest) GetSeq() int              { return m.Seq }
+func (m *LoadedSourcesResponse) GetSeq() int             { return m.Seq }
+func (m *EvaluateRequest) GetSeq() int                   { return m.Seq }
+func (m *EvaluateResponse) GetSeq() int                  { return m.Seq }
+func (m *SetExpressionRequest) GetSeq() int              { return m.Seq }
+func (m *SetExpressionResponse) GetSeq() int             { return m.Seq }
+func (m *StepInTargetsRequest) GetSeq() int              { return m.Seq }
+func (m *StepInTargetsResponse) GetSeq() int             { return m.Seq }
+func (m *GotoTargetsRequest) GetSeq() int                { return m.Seq }
+func (m *GotoTargetsResponse) GetSeq() int               { return m.Seq }
+func (m *CompletionsRequest) GetSeq() int                { return m.Seq }
+func (m *CompletionsResponse) GetSeq() int               { return m.Seq }
+func (m *ExceptionInfoRequest) GetSeq() int              { return m.Seq }
+func (m *ExceptionInfoResponse) GetSeq() int             { return m.Seq }
+func (m *ReadMemoryRequest) GetSeq() int                 { return m.Seq }
+func (m *ReadMemoryResponse) GetSeq() int                { return m.Seq }
+func (m *DisassembleRequest) GetSeq() int                { return m.Seq }
+func (m *DisassembleResponse) GetSeq() int               { return m.Seq }


### PR DESCRIPTION
This should go in after #43 to avoid churn of the generated `GetSeq` methods - after #43 the diff on schematypes.go will be much smaller.