### PR TITLE
Fix failing server test

### DIFF
--- a/cmd/gentypes/gentypes.go
+++ b/cmd/gentypes/gentypes.go
@@ -286,9 +286,10 @@ func emitToplevelType(typeName string, descJson json.RawMessage) string {
 			if requiredMap[propName] {
 				jsonTag += "\"`"
 			} else if typeName == "ContinueResponseBody" && propName == "allThreadsContinued" {
-				// This one special field must not have the omitempty tag, despite being optional.
-				// If this attribute is missing the client will (according to the specification) assume a value of 'true' for backward compatibility.
-				// See: https://github.com/google/go-dap/issues/39
+				// This one special field must not have the omitempty tag, despite being
+				// optional. If this attribute is missing the client will (according to
+				// the specification) assume a value of 'true' for backward
+				// compatibility. See: https://github.com/google/go-dap/issues/39
 				jsonTag += "\"`"
 			} else {
 				jsonTag += ",omitempty\"`"

--- a/cmd/mockserver/server_test.go
+++ b/cmd/mockserver/server_test.go
@@ -59,7 +59,7 @@ var variablesRequest = []byte(`{"seq":9,"type":"request","command":"variables","
 var variablesResponse = []byte(`{"seq":0,"type":"response","request_seq":9,"success":true,"command":"variables","body":{"variables":[{"name":"i","value":"18434528","presentationHint":{},"evaluateName":"i","variablesReference":0}]}}`)
 
 var continueRequest = []byte(`{"seq":10,"type":"request","command":"continue","arguments":{"threadId":1}}`)
-var continueResponse = []byte(`{"seq":0,"type":"response","request_seq":10,"success":true,"command":"continue","body":{}}`)
+var continueResponse = []byte(`{"seq":0,"type":"response","request_seq":10,"success":true,"command":"continue","body":{"allThreadsContinued":false}}`)
 
 var terminatedEvent = []byte(`{"seq":0,"type":"event","event":"terminated","body":{}}`)
 var disconnectRequest = []byte(`{"seq":11,"type":"request","command":"disconnect","arguments":{"restart":false}}`)


### PR DESCRIPTION
Test fails since #40 removed "omitempty" from allThreadsContinued, and the
test expects hard-coded JSON strings for the responses.
