### PR TITLE
AttachRequest.Arguments should be an arbitrary map

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -128,7 +128,7 @@ var launchResponseStruct = LaunchResponse{Response: *newResponse(3, 4, "launch",
 var attachRequestString = `{"seq":4,"type":"request","command":"attach","arguments":{}}`
 var attachRequestStruct = AttachRequest{
 	Request:   *newRequest(4, "attach"),
-	Arguments: AttachRequestArguments{},
+	Arguments: map[string]interface{}{},
 }
 
 var attachResponseString = `{"seq":4,"type":"response","request_seq":5,"command":"attach","success":true}`

--- a/schematypes.go
+++ b/schematypes.go
@@ -49,6 +49,16 @@ type EventMessage interface {
 	GetEvent() *Event
 }
 
+// LaunchAttachRequest is an interface implemented by
+// LaunchRequest and AttachRequest as they contain shared
+// implementation specific arguments that are not part of
+// the specification.
+type LaunchAttachRequest interface {
+	RequestMessage
+	// GetArguments provides access to the Arguments map.
+	GetArguments() map[string]interface{}
+}
+
 // ProtocolMessage: Base class of requests, responses, and events.
 type ProtocolMessage struct {
 	Seq  int    `json:"seq"`
@@ -466,7 +476,8 @@ type LaunchRequest struct {
 	Arguments map[string]interface{} `json:"arguments"`
 }
 
-func (r *LaunchRequest) GetRequest() *Request { return &r.Request }
+func (r *LaunchRequest) GetRequest() *Request                 { return &r.Request }
+func (r *LaunchRequest) GetArguments() map[string]interface{} { return r.Arguments }
 
 // LaunchResponse: Response to 'launch' request. This is just an acknowledgement, so no body field is required.
 type LaunchResponse struct {
@@ -480,15 +491,11 @@ func (r *LaunchResponse) GetResponse() *Response { return &r.Response }
 type AttachRequest struct {
 	Request
 
-	Arguments AttachRequestArguments `json:"arguments"`
+	Arguments map[string]interface{} `json:"arguments"`
 }
 
-func (r *AttachRequest) GetRequest() *Request { return &r.Request }
-
-// AttachRequestArguments: Arguments for 'attach' request. Additional attributes are implementation specific.
-type AttachRequestArguments struct {
-	Restart interface{} `json:"__restart,omitempty"`
-}
+func (r *AttachRequest) GetRequest() *Request                 { return &r.Request }
+func (r *AttachRequest) GetArguments() map[string]interface{} { return r.Arguments }
 
 // AttachResponse: Response to 'attach' request. This is just an acknowledgement, so no body field is required.
 type AttachResponse struct {

--- a/schematypes_test.go
+++ b/schematypes_test.go
@@ -70,3 +70,43 @@ func TestReponseMessageInterface(t *testing.T) {
 		t.Errorf("got ResponseSeq=%d, want 9", rseq)
 	}
 }
+
+func TestLaunchAttachRequestInterface(t *testing.T) {
+	lr := &LaunchRequest{
+		Request: Request{
+			ProtocolMessage: ProtocolMessage{
+				Seq:  19,
+				Type: "request",
+			},
+			Command: "launch",
+		},
+		Arguments: map[string]interface{}{"foo": "bar"},
+	}
+	ar := &AttachRequest{
+		Request: Request{
+			ProtocolMessage: ProtocolMessage{
+				Seq:  19,
+				Type: "request",
+			},
+			Command: "attach",
+		},
+		Arguments: map[string]interface{}{"foo": "bar"},
+	}
+
+	f := func(r LaunchAttachRequest) (int, string, interface{}) {
+		return r.GetSeq(), r.GetRequest().Command, r.GetArguments()["foo"]
+	}
+	// Test adherence to the LaunchAttachRequest interface.
+	lseq, lcmd, lfoo := f(lr)
+	aseq, acmd, afoo := f(ar)
+
+	if lseq != 19 || aseq != 19 {
+		t.Errorf("got lseq=%d aseq=%d, want 19", lseq, aseq)
+	}
+	if lcmd != "launch" || acmd != "attach" {
+		t.Errorf("got lcmd=%s acmd=%s, want (\"launch\", \"attach\")", lcmd, acmd)
+	}
+	if lfoo != "bar" || afoo != "bar" {
+		t.Errorf("got lfoo=%s afoo=%s, want \"bar\"", lfoo, afoo)
+	}
+}


### PR DESCRIPTION
Replace AttachRequestArguments type with just a map, same way we have this for LaunchRequest. The arguments are implementation specific and can overlap between the requests. Create a shared interface with to access them. 