### PR TITLE
Fix int overflow on 32bit

### DIFF
--- a/io.go
+++ b/io.go
@@ -95,7 +95,7 @@ func ReadBaseMessage(r *bufio.Reader) ([]byte, error) {
 // and required:
 // 		Content-Length: [0-9]+\r\n\r\n
 // Extracts and returns the content length.
-func readContentLengthHeader(r *bufio.Reader) (contentLength int, err error) {
+func readContentLengthHeader(r *bufio.Reader) (contentLength int64, err error) {
 	// Look for <some header>\r\n\r\n
 	headerWithCr, err := r.ReadString('\r')
 	if err != nil {
@@ -115,7 +115,7 @@ func readContentLengthHeader(r *bufio.Reader) (contentLength int, err error) {
 	if len(headerAndLength) < 2 {
 		return 0, ErrHeaderNotContentLength
 	}
-	return strconv.Atoi(headerAndLength[1])
+	return strconv.ParseInt(headerAndLength[1], 10, 64)
 }
 
 // WriteProtocolMessage encodes message and writes it to w.

--- a/io_test.go
+++ b/io_test.go
@@ -90,7 +90,7 @@ func Test_readContentLengthHeader(t *testing.T) {
 	tests := []struct {
 		input         string
 		wantBytesLeft string // Bytes left in the reader after header reading
-		wantLen       int    // Extracted content length value
+		wantLen       int64  // Extracted content length value
 		wantErr       error
 	}{
 		{"", "", 0, io.EOF},


### PR DESCRIPTION
Test_readContentLengthHeader has one case that has large const.
It overflows 32bit int, then causes test failure.

io_test.go:120:61: constant 9223372036854775807 overflows int