### PR TITLE
Add default values for initialize request arguments

### DIFF
--- a/cmd/gentypes/gentypes.go
+++ b/cmd/gentypes/gentypes.go
@@ -294,7 +294,7 @@ func emitToplevelType(typeName string, descJson json.RawMessage) string {
 				// compatibility. See: https://github.com/google/go-dap/issues/39
 				jsonTag += "\"`"
 			} else if typeName == "InitializeRequestArguments" && (propName == "linesStartAt1" || propName == "columnsStartAt1") {
-				// These two special field must not have the omitempty tag, despite being
+				// These two special fields must not have the omitempty tag, despite being
 				// optional. If this attribute is missing the server will (according to
 				// the specification) assume a value of 'true'.
 				jsonTag += "\"`"

--- a/cmd/gentypes/gentypes.go
+++ b/cmd/gentypes/gentypes.go
@@ -293,6 +293,11 @@ func emitToplevelType(typeName string, descJson json.RawMessage) string {
 				// the specification) assume a value of 'true' for backward
 				// compatibility. See: https://github.com/google/go-dap/issues/39
 				jsonTag += "\"`"
+			} else if typeName == "InitializeRequestArguments" && (propName == "linesStartAt1" || propName == "columnsStartAt1") {
+				// These two special field must not have the omitempty tag, despite being
+				// optional. If this attribute is missing the server will (according to
+				// the specification) assume a value of 'true'.
+				jsonTag += "\"`"
 			} else {
 				jsonTag += ",omitempty\"`"
 			}

--- a/codec.go
+++ b/codec.go
@@ -75,9 +75,18 @@ func decodeRequest(data []byte) (Message, error) {
 // Mapping of request commands and corresponding struct constructors that
 // can be passed to json.Unmarshal.
 var requestCtor = map[string]messageCtor{
-	"cancel":                  func() Message { return &CancelRequest{} },
-	"runInTerminal":           func() Message { return &RunInTerminalRequest{} },
-	"initialize":              func() Message { return &InitializeRequest{} },
+	"cancel":        func() Message { return &CancelRequest{} },
+	"runInTerminal": func() Message { return &RunInTerminalRequest{} },
+	"initialize": func() Message {
+		return &InitializeRequest{
+			Arguments: InitializeRequestArguments{
+				// Set the default values specified here: https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Initialize.
+				LinesStartAt1:   true,
+				ColumnsStartAt1: true,
+				PathFormat:      "path",
+			},
+		}
+	},
 	"configurationDone":       func() Message { return &ConfigurationDoneRequest{} },
 	"launch":                  func() Message { return &LaunchRequest{} },
 	"attach":                  func() Message { return &AttachRequest{} },

--- a/codec_test.go
+++ b/codec_test.go
@@ -76,6 +76,7 @@ var runInTerminalResponseStruct = RunInTerminalResponse{
 // -------- Initialize
 
 var initializeRequestString = `{"seq":1,"type":"request","command":"initialize","arguments":{"clientID":"vscode","clientName":"Visual Studio Code","adapterID":"go","pathFormat":"path","linesStartAt1":true,"columnsStartAt1":true,"supportsVariableType":true,"supportsVariablePaging":true,"supportsRunInTerminalRequest":true,"locale":"en-us"}}`
+var initializeRequestOmitDefaultsString = `{"seq":1,"type":"request","command":"initialize","arguments":{"clientID":"vscode","clientName":"Visual Studio Code","adapterID":"go","supportsVariableType":true,"supportsVariablePaging":true,"supportsRunInTerminalRequest":true,"locale":"en-us"}}`
 var initializeRequestStruct = InitializeRequest{
 	Request: *newRequest(1, "initialize"),
 	Arguments: InitializeRequestArguments{
@@ -85,6 +86,23 @@ var initializeRequestStruct = InitializeRequest{
 		PathFormat:                   "path",
 		LinesStartAt1:                true,
 		ColumnsStartAt1:              true,
+		SupportsVariableType:         true,
+		SupportsVariablePaging:       true,
+		SupportsRunInTerminalRequest: true,
+		Locale:                       "en-us",
+	},
+}
+
+var initializeRequestNotDefaultsString = `{"seq":1,"type":"request","command":"initialize","arguments":{"clientID":"vscode","clientName":"Visual Studio Code","adapterID":"go","pathFormat":"url","linesStartAt1":false,"columnsStartAt1":false,"supportsVariableType":true,"supportsVariablePaging":true,"supportsRunInTerminalRequest":true,"locale":"en-us"}}`
+var initializeRequestNotDefaultsStruct = InitializeRequest{
+	Request: *newRequest(1, "initialize"),
+	Arguments: InitializeRequestArguments{
+		ClientID:                     "vscode",
+		ClientName:                   "Visual Studio Code",
+		AdapterID:                    "go",
+		PathFormat:                   "url",
+		LinesStartAt1:                false,
+		ColumnsStartAt1:              false,
 		SupportsVariableType:         true,
 		SupportsVariablePaging:       true,
 		SupportsRunInTerminalRequest: true,
@@ -823,7 +841,8 @@ func Test_DecodeProtocolMessage(t *testing.T) {
 		{cancelRequestString, &cancelRequestStruct, noError},
 		{runInTerminalRequestString, &runInTerminalRequestStruct, noError},
 		{initializeRequestString, &initializeRequestStruct, noError},
-		{initializeRequestString, &initializeRequestStruct, noError},
+		{initializeRequestOmitDefaultsString, &initializeRequestStruct, noError},
+		{initializeRequestNotDefaultsString, &initializeRequestNotDefaultsStruct, noError},
 		{configurationDoneRequestString, &configurationDoneRequestStruct, noError},
 		{launchRequestString, &launchRequestStruct, noError},
 		{attachRequestString, &attachRequestStruct, noError},
@@ -867,7 +886,6 @@ func Test_DecodeProtocolMessage(t *testing.T) {
 		{errorResponseString, &errorResponseStruct, noError},
 		{cancelResponseString, &cancelResponseStruct, noError},
 		{runInTerminalResponseString, &runInTerminalResponseStruct, noError},
-		{initializeResponseString, &initializeResponseStruct, noError},
 		{initializeResponseString, &initializeResponseStruct, noError},
 		{configurationDoneResponseString, &configurationDoneResponseStruct, noError},
 		{launchResponseString, &launchResponseStruct, noError},
@@ -973,5 +991,31 @@ func newResponse(seq int, requestSeq int, command string, success bool) *Respons
 		Command:    command,
 		RequestSeq: requestSeq,
 		Success:    success,
+	}
+}
+
+func TestDecodeRequest(t *testing.T) {
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Message
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decodeRequest(tt.args.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("decodeRequest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("decodeRequest() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/codec_test.go
+++ b/codec_test.go
@@ -993,29 +993,3 @@ func newResponse(seq int, requestSeq int, command string, success bool) *Respons
 		Success:    success,
 	}
 }
-
-func TestDecodeRequest(t *testing.T) {
-	type args struct {
-		data []byte
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    Message
-		wantErr bool
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := decodeRequest(tt.args.data)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("decodeRequest() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("decodeRequest() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}

--- a/schematypes.go
+++ b/schematypes.go
@@ -427,8 +427,8 @@ type InitializeRequestArguments struct {
 	ClientName                   string `json:"clientName,omitempty"`
 	AdapterID                    string `json:"adapterID"`
 	Locale                       string `json:"locale,omitempty"`
-	LinesStartAt1                bool   `json:"linesStartAt1,omitempty"`
-	ColumnsStartAt1              bool   `json:"columnsStartAt1,omitempty"`
+	LinesStartAt1                bool   `json:"linesStartAt1"`
+	ColumnsStartAt1              bool   `json:"columnsStartAt1"`
 	PathFormat                   string `json:"pathFormat,omitempty"`
 	SupportsVariableType         bool   `json:"supportsVariableType,omitempty"`
 	SupportsVariablePaging       bool   `json:"supportsVariablePaging,omitempty"`

--- a/schematypes.go
+++ b/schematypes.go
@@ -427,8 +427,8 @@ type InitializeRequestArguments struct {
 	ClientName                   string `json:"clientName,omitempty"`
 	AdapterID                    string `json:"adapterID"`
 	Locale                       string `json:"locale,omitempty"`
-	LinesStartAt1                bool   `json:"linesStartAt1"`
-	ColumnsStartAt1              bool   `json:"columnsStartAt1"`
+	LinesStartAt1                bool   `json:"linesStartAt1,omitempty"`
+	ColumnsStartAt1              bool   `json:"columnsStartAt1,omitempty"`
 	PathFormat                   string `json:"pathFormat,omitempty"`
 	SupportsVariableType         bool   `json:"supportsVariableType,omitempty"`
 	SupportsVariablePaging       bool   `json:"supportsVariablePaging,omitempty"`


### PR DESCRIPTION
The DAP spec includes that the default values for LinesStartAt1,
ColumnsStartAt1 and PathFormat are nonzero values (true, true, and
"path"). Set these values before decoding.

Additionally, remove the omitzero flags from LinesStartAt1 and
ColumnsStartAt1, since this will not send the value if they are
false.