### PR TITLE
all: use json.RawMessage for launch/attach arguments

### DIFF
--- a/cmd/gentypes/gentypes.go
+++ b/cmd/gentypes/gentypes.go
@@ -291,7 +291,7 @@ func emitToplevelType(typeName string, descJson json.RawMessage) string {
 		} else if propName == "arguments" && (typeName == "LaunchRequest" || typeName == "AttachRequest") {
 			// Special case for LaunchRequest or AttachRequest arguments, which are implementation
 			// defined and don't have pre-set field names in the specification.
-			fmt.Fprintln(&b, "\tArguments map[string]interface{} `json:\"arguments\"`")
+			fmt.Fprintln(&b, "\tArguments json.RawMessage `json:\"arguments\"`")
 		} else {
 			// Go type of this property.
 			goType := parsePropertyType(propDesc)
@@ -416,7 +416,7 @@ func emitMethodsForType(sb *strings.Builder, typeName string) {
 		fmt.Fprintf(sb, "func (e *%s) GetEvent() *Event {return &e.Event}\n", typeName)
 	}
 	if typeName == "LaunchRequest" || typeName == "AttachRequest" {
-		fmt.Fprintf(sb, "func (r *%s) GetArguments() map[string]interface{} { return r.Arguments }\n", typeName)
+		fmt.Fprintf(sb, "func (r *%s) GetArguments() json.RawMessage { return r.Arguments }\n", typeName)
 	}
 }
 
@@ -439,6 +439,8 @@ const preamble = `// Copyright 2020 Google LLC
 // See cmd/gentypes/README.md for additional details.
 
 package dap
+
+import "encoding/json"
 
 // Message is an interface that all DAP message types implement with pointer
 // receivers. It's not part of the protocol but is used to enforce static
@@ -478,7 +480,7 @@ type EventMessage interface {
 type LaunchAttachRequest interface {
 	RequestMessage
 	// GetArguments provides access to the Arguments map.
-	GetArguments() map[string]interface{}
+	GetArguments() json.RawMessage
 }
 `
 

--- a/codec_test.go
+++ b/codec_test.go
@@ -15,8 +15,8 @@
 package dap
 
 import (
-	"bytes"
 	"encoding/json"
+	"reflect"
 	"testing"
 )
 
@@ -133,10 +133,10 @@ var configurationDoneResponseStruct = ConfigurationDoneResponse{Response: *newRe
 
 // -------- Launch
 
-var launchRequestString = `{"seq":3,"type":"request","command":"launch","arguments":{"name":"Launch","noDebug":true}}` // map keys are sorted.
+var launchRequestString = `{"seq":3,"type":"request","command":"launch","arguments":{"noDebug":true,"name":"Launch"}}`
 var launchRequestStruct = LaunchRequest{
 	Request:   *newRequest(3, "launch"),
-	Arguments: toRawMessage(map[string]interface{}{"noDebug": true, "name": "Launch"}),
+	Arguments: json.RawMessage(`{"noDebug":true,"name":"Launch"}`),
 }
 
 var launchResponseString = `{"seq":3,"type":"response","request_seq":4,"command":"launch","success":true}`
@@ -147,7 +147,7 @@ var launchResponseStruct = LaunchResponse{Response: *newResponse(3, 4, "launch",
 var attachRequestString = `{"seq":4,"type":"request","command":"attach","arguments":{}}`
 var attachRequestStruct = AttachRequest{
 	Request:   *newRequest(4, "attach"),
-	Arguments: toRawMessage(map[string]interface{}{}),
+	Arguments: json.RawMessage(`{}`),
 }
 
 var attachResponseString = `{"seq":4,"type":"response","request_seq":5,"command":"attach","success":true}`
@@ -954,7 +954,7 @@ func Test_DecodeProtocolMessage(t *testing.T) {
 				}
 				got, _ := json.Marshal(msg)
 				want, _ := json.Marshal(test.wantMsg)
-				if !bytes.Equal(got, want) {
+				if !reflect.DeepEqual(msg, test.wantMsg) { // Check result
 					t.Errorf("\ngot message\n%s\nwant\n%s", got, want)
 				}
 			}

--- a/schematypes.go
+++ b/schematypes.go
@@ -18,6 +18,8 @@
 
 package dap
 
+import "encoding/json"
+
 // Message is an interface that all DAP message types implement with pointer
 // receivers. It's not part of the protocol but is used to enforce static
 // typing in Go code and provide some common accessors.
@@ -56,7 +58,7 @@ type EventMessage interface {
 type LaunchAttachRequest interface {
 	RequestMessage
 	// GetArguments provides access to the Arguments map.
-	GetArguments() map[string]interface{}
+	GetArguments() json.RawMessage
 }
 
 // ProtocolMessage: Base class of requests, responses, and events.
@@ -492,11 +494,11 @@ func (r *ConfigurationDoneResponse) GetResponse() *Response { return &r.Response
 type LaunchRequest struct {
 	Request
 
-	Arguments map[string]interface{} `json:"arguments"`
+	Arguments json.RawMessage `json:"arguments"`
 }
 
-func (r *LaunchRequest) GetRequest() *Request                 { return &r.Request }
-func (r *LaunchRequest) GetArguments() map[string]interface{} { return r.Arguments }
+func (r *LaunchRequest) GetRequest() *Request          { return &r.Request }
+func (r *LaunchRequest) GetArguments() json.RawMessage { return r.Arguments }
 
 // LaunchResponse: Response to 'launch' request. This is just an acknowledgement, so no body field is required.
 type LaunchResponse struct {
@@ -510,11 +512,11 @@ func (r *LaunchResponse) GetResponse() *Response { return &r.Response }
 type AttachRequest struct {
 	Request
 
-	Arguments map[string]interface{} `json:"arguments"`
+	Arguments json.RawMessage `json:"arguments"`
 }
 
-func (r *AttachRequest) GetRequest() *Request                 { return &r.Request }
-func (r *AttachRequest) GetArguments() map[string]interface{} { return r.Arguments }
+func (r *AttachRequest) GetRequest() *Request          { return &r.Request }
+func (r *AttachRequest) GetArguments() json.RawMessage { return r.Arguments }
 
 // AttachResponse: Response to 'attach' request. This is just an acknowledgement, so no body field is required.
 type AttachResponse struct {

--- a/schematypes_test.go
+++ b/schematypes_test.go
@@ -15,6 +15,7 @@
 package dap
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -40,6 +41,17 @@ func makeErrorResponse() *ErrorResponse {
 			},
 		},
 	}
+}
+
+func toRawMessage(m interface{}) json.RawMessage {
+	b, _ := json.Marshal(m)
+	return (json.RawMessage)(b)
+}
+
+func fromRawMessage(b json.RawMessage) map[string]interface{} {
+	m := make(map[string]interface{})
+	_ = json.Unmarshal(b, &m)
+	return m
 }
 
 func TestMessageInterface(t *testing.T) {
@@ -80,7 +92,7 @@ func TestLaunchAttachRequestInterface(t *testing.T) {
 			},
 			Command: "launch",
 		},
-		Arguments: map[string]interface{}{"foo": "bar"},
+		Arguments: toRawMessage(map[string]interface{}{"foo": "bar"}),
 	}
 	ar := &AttachRequest{
 		Request: Request{
@@ -90,11 +102,11 @@ func TestLaunchAttachRequestInterface(t *testing.T) {
 			},
 			Command: "attach",
 		},
-		Arguments: map[string]interface{}{"foo": "bar"},
+		Arguments: toRawMessage(map[string]interface{}{"foo": "bar"}),
 	}
 
 	f := func(r LaunchAttachRequest) (int, string, interface{}) {
-		return r.GetSeq(), r.GetRequest().Command, r.GetArguments()["foo"]
+		return r.GetSeq(), r.GetRequest().Command, fromRawMessage(r.GetArguments())["foo"]
 	}
 	// Test adherence to the LaunchAttachRequest interface.
 	lseq, lcmd, lfoo := f(lr)
@@ -107,6 +119,6 @@ func TestLaunchAttachRequestInterface(t *testing.T) {
 		t.Errorf("got lcmd=%s acmd=%s, want (\"launch\", \"attach\")", lcmd, acmd)
 	}
 	if lfoo != "bar" || afoo != "bar" {
-		t.Errorf("got lfoo=%s afoo=%s, want \"bar\"", lfoo, afoo)
+		t.Errorf("got lfoo=%v afoo=%v, want \"bar\"", lfoo, afoo)
 	}
 }


### PR DESCRIPTION
Launch/Attach requests' arguments are supposed to be implementation
specific. By defining them as json.RawMessage, we leave decoding &
encoding of these fields up to the implementation.

Updates https://github.com/go-delve/delve/pull/2571