### PR TITLE
gentypes: no omitempty for ErrorMessage.ShowUser

### DIFF
--- a/cmd/gentypes/gentypes.go
+++ b/cmd/gentypes/gentypes.go
@@ -310,6 +310,10 @@ func emitToplevelType(typeName string, descJson json.RawMessage) string {
 				// optional. If this attribute is missing the server will (according to
 				// the specification) assume a value of 'true'.
 				jsonTag += "\"`"
+			} else if typeName == "ErrorMessage" && propName == "showUser" {
+				// For launch/attach errors, vscode will treat omitted values the same way as true,
+				// so to supress visible reporting, we must report false explicitly.
+				jsonTag += "\"`"
 			} else {
 				jsonTag += ",omitempty\"`"
 			}

--- a/schematypes.go
+++ b/schematypes.go
@@ -1612,7 +1612,7 @@ type ErrorMessage struct {
 	Format        string            `json:"format"`
 	Variables     map[string]string `json:"variables,omitempty"`
 	SendTelemetry bool              `json:"sendTelemetry,omitempty"`
-	ShowUser      bool              `json:"showUser,omitempty"`
+	ShowUser      bool              `json:"showUser"`
 	Url           string            `json:"url,omitempty"`
 	UrlLabel      string            `json:"urlLabel,omitempty"`
 }


### PR DESCRIPTION
See microsoft/vscode#128484 for context.