### PR TITLE
cmd/gentypes: generate response and event ctor

### DIFF
--- a/cmd/gentypes/gentypes.go
+++ b/cmd/gentypes/gentypes.go
@@ -425,25 +425,35 @@ func emitMethodsForType(sb *strings.Builder, typeName string) {
 	}
 }
 
-func getResponseAndEventTypes(resps, events []string, typeName string) ([]string, []string) {
-	if strings.HasSuffix(typeName, "Response") && typeName != "Response" && typeName != "ErrorResponse" {
-		resps = append(resps, typeName)
+func emitCtor(sb *strings.Builder, reqs, resps, events []string) {
+	fmt.Fprint(sb, `
+// Mapping of request commands and corresponding struct constructors that
+// can be passed to json.Unmarshal.
+var requestCtor = map[string]messageCtor{`)
+	for _, r := range reqs {
+		req := strings.TrimSuffix(firstToLower(r), "Request")
+		var msg string
+		if req == "initialize" {
+			msg = `
+	Arguments: InitializeRequestArguments{
+		// Set the default values specified here: https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Initialize.
+		LinesStartAt1:   true,
+		ColumnsStartAt1: true,
+		PathFormat:      "path",
+}`
+		}
+		fmt.Fprintf(sb, "\n\t\"%s\":\tfunc() Message { return &%s{%s} },", req, r, msg)
 	}
-	if strings.HasSuffix(typeName, "Event") && typeName != "Event" {
-		events = append(events, typeName)
-	}
-	return resps, events
-}
+	fmt.Fprint(sb, "\n}")
 
-func emitCtor(sb *strings.Builder, resps, events []string) {
 	fmt.Fprint(sb, `
 // Mapping of response commands and corresponding struct constructors that
 // can be passed to json.Unmarshal.
 var responseCtor = map[string]messageCtor{`)
 	for _, r := range resps {
-		req := strings.TrimSuffix(firstToLower(r), "Response")
+		resp := strings.TrimSuffix(firstToLower(r), "Response")
 
-		fmt.Fprintf(sb, "\n\t\"%s\":\tfunc() Message { return &%s{} },", req, r)
+		fmt.Fprintf(sb, "\n\t\"%s\":\tfunc() Message { return &%s{} },", resp, r)
 	}
 	fmt.Fprint(sb, "\n}")
 
@@ -576,7 +586,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	var responses, events []string
+	var requests, responses, events []string
 	for _, typeName := range typeNames {
 		if _, ok := typesExcludeList[typeName]; !ok {
 			b.WriteString(emitToplevelType(replaceGoTypename(typeName), typeMap[typeName]))
@@ -584,11 +594,20 @@ func main() {
 		}
 
 		emitMethodsForType(&b, replaceGoTypename(typeName))
-		responses, events = getResponseAndEventTypes(responses, events, replaceGoTypename(typeName))
+		// Add the typename to the appropriate list.
+		if strings.HasSuffix(typeName, "Request") && typeName != "Request" {
+			requests = append(requests, typeName)
+		}
+		if strings.HasSuffix(typeName, "Response") && typeName != "Response" && typeName != "ErrorResponse" {
+			responses = append(responses, typeName)
+		}
+		if strings.HasSuffix(typeName, "Event") && typeName != "Event" {
+			events = append(events, typeName)
+		}
 	}
 
 	// Emit the maps from id to response and event types.
-	emitCtor(&b, responses, events)
+	emitCtor(&b, requests, responses, events)
 
 	wholeFile := []byte(b.String())
 	formatted, err := format.Source(wholeFile)

--- a/cmd/gentypes/gentypes.go
+++ b/cmd/gentypes/gentypes.go
@@ -440,7 +440,8 @@ var requestCtor = map[string]messageCtor{`)
 		LinesStartAt1:   true,
 		ColumnsStartAt1: true,
 		PathFormat:      "path",
-}`
+},
+`
 		}
 		fmt.Fprintf(sb, "\n\t\"%s\":\tfunc() Message { return &%s{%s} },", req, r, msg)
 	}

--- a/codec.go
+++ b/codec.go
@@ -73,61 +73,6 @@ func decodeRequest(data []byte) (Message, error) {
 	return nil, &DecodeProtocolMessageFieldError{r.GetSeq(), "Request", "command", r.Command}
 }
 
-// Mapping of request commands and corresponding struct constructors that
-// can be passed to json.Unmarshal.
-var requestCtor = map[string]messageCtor{
-	"cancel":        func() Message { return &CancelRequest{} },
-	"runInTerminal": func() Message { return &RunInTerminalRequest{} },
-	"initialize": func() Message {
-		return &InitializeRequest{
-			Arguments: InitializeRequestArguments{
-				// Set the default values specified here: https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Initialize.
-				LinesStartAt1:   true,
-				ColumnsStartAt1: true,
-				PathFormat:      "path",
-			},
-		}
-	},
-	"configurationDone":       func() Message { return &ConfigurationDoneRequest{} },
-	"launch":                  func() Message { return &LaunchRequest{} },
-	"attach":                  func() Message { return &AttachRequest{} },
-	"restart":                 func() Message { return &RestartRequest{} },
-	"disconnect":              func() Message { return &DisconnectRequest{} },
-	"terminate":               func() Message { return &TerminateRequest{} },
-	"breakpointLocations":     func() Message { return &BreakpointLocationsRequest{} },
-	"setBreakpoints":          func() Message { return &SetBreakpointsRequest{} },
-	"setFunctionBreakpoints":  func() Message { return &SetFunctionBreakpointsRequest{} },
-	"setExceptionBreakpoints": func() Message { return &SetExceptionBreakpointsRequest{} },
-	"dataBreakpointInfo":      func() Message { return &DataBreakpointInfoRequest{} },
-	"setDataBreakpoints":      func() Message { return &SetDataBreakpointsRequest{} },
-	"continue":                func() Message { return &ContinueRequest{} },
-	"next":                    func() Message { return &NextRequest{} },
-	"stepIn":                  func() Message { return &StepInRequest{} },
-	"stepOut":                 func() Message { return &StepOutRequest{} },
-	"stepBack":                func() Message { return &StepBackRequest{} },
-	"reverseContinue":         func() Message { return &ReverseContinueRequest{} },
-	"restartFrame":            func() Message { return &RestartFrameRequest{} },
-	"goto":                    func() Message { return &GotoRequest{} },
-	"pause":                   func() Message { return &PauseRequest{} },
-	"stackTrace":              func() Message { return &StackTraceRequest{} },
-	"scopes":                  func() Message { return &ScopesRequest{} },
-	"variables":               func() Message { return &VariablesRequest{} },
-	"setVariable":             func() Message { return &SetVariableRequest{} },
-	"source":                  func() Message { return &SourceRequest{} },
-	"threads":                 func() Message { return &ThreadsRequest{} },
-	"terminateThreads":        func() Message { return &TerminateThreadsRequest{} },
-	"modules":                 func() Message { return &ModulesRequest{} },
-	"loadedSources":           func() Message { return &LoadedSourcesRequest{} },
-	"evaluate":                func() Message { return &EvaluateRequest{} },
-	"setExpression":           func() Message { return &SetExpressionRequest{} },
-	"stepInTargets":           func() Message { return &StepInTargetsRequest{} },
-	"gotoTargets":             func() Message { return &GotoTargetsRequest{} },
-	"completions":             func() Message { return &CompletionsRequest{} },
-	"exceptionInfo":           func() Message { return &ExceptionInfoRequest{} },
-	"readMemory":              func() Message { return &ReadMemoryRequest{} },
-	"disassemble":             func() Message { return &DisassembleRequest{} },
-}
-
 // decodeResponse determines what response type in the ProtocolMessage hierarchy
 // data corresponds to and uses json.Unmarshal to populate the corresponding
 // struct to be returned.

--- a/codec.go
+++ b/codec.go
@@ -149,52 +149,6 @@ func decodeResponse(data []byte) (Message, error) {
 	return nil, &DecodeProtocolMessageFieldError{r.GetSeq(), "Response", "command", r.Command}
 }
 
-// Mapping of response commands and corresponding struct constructors that
-// can be passed to json.Unmarshal.
-var responseCtor = map[string]messageCtor{
-	"cancel":                  func() Message { return &CancelResponse{} },
-	"runInTerminal":           func() Message { return &RunInTerminalResponse{} },
-	"initialize":              func() Message { return &InitializeResponse{} },
-	"configurationDone":       func() Message { return &ConfigurationDoneResponse{} },
-	"launch":                  func() Message { return &LaunchResponse{} },
-	"attach":                  func() Message { return &AttachResponse{} },
-	"restart":                 func() Message { return &RestartResponse{} },
-	"disconnect":              func() Message { return &DisconnectResponse{} },
-	"terminate":               func() Message { return &TerminateResponse{} },
-	"breakpointLocations":     func() Message { return &BreakpointLocationsResponse{} },
-	"setBreakpoints":          func() Message { return &SetBreakpointsResponse{} },
-	"setFunctionBreakpoints":  func() Message { return &SetFunctionBreakpointsResponse{} },
-	"setExceptionBreakpoints": func() Message { return &SetExceptionBreakpointsResponse{} },
-	"dataBreakpointInfo":      func() Message { return &DataBreakpointInfoResponse{} },
-	"setDataBreakpoints":      func() Message { return &SetDataBreakpointsResponse{} },
-	"continue":                func() Message { return &ContinueResponse{} },
-	"next":                    func() Message { return &NextResponse{} },
-	"stepIn":                  func() Message { return &StepInResponse{} },
-	"stepOut":                 func() Message { return &StepOutResponse{} },
-	"stepBack":                func() Message { return &StepBackResponse{} },
-	"reverseContinue":         func() Message { return &ReverseContinueResponse{} },
-	"restartFrame":            func() Message { return &RestartFrameResponse{} },
-	"goto":                    func() Message { return &GotoResponse{} },
-	"pause":                   func() Message { return &PauseResponse{} },
-	"stackTrace":              func() Message { return &StackTraceResponse{} },
-	"scopes":                  func() Message { return &ScopesResponse{} },
-	"variables":               func() Message { return &VariablesResponse{} },
-	"setVariable":             func() Message { return &SetVariableResponse{} },
-	"source":                  func() Message { return &SourceResponse{} },
-	"threads":                 func() Message { return &ThreadsResponse{} },
-	"terminateThreads":        func() Message { return &TerminateThreadsResponse{} },
-	"modules":                 func() Message { return &ModulesResponse{} },
-	"loadedSources":           func() Message { return &LoadedSourcesResponse{} },
-	"evaluate":                func() Message { return &EvaluateResponse{} },
-	"setExpression":           func() Message { return &SetExpressionResponse{} },
-	"stepInTargets":           func() Message { return &StepInTargetsResponse{} },
-	"gotoTargets":             func() Message { return &GotoTargetsResponse{} },
-	"completions":             func() Message { return &CompletionsResponse{} },
-	"exceptionInfo":           func() Message { return &ExceptionInfoResponse{} },
-	"readMemory":              func() Message { return &ReadMemoryResponse{} },
-	"disassemble":             func() Message { return &DisassembleResponse{} },
-}
-
 // decodeEvent determines what event type in the ProtocolMessage hierarchy
 // data corresponds to and uses json.Unmarshal to populate the corresponding
 // struct to be returned.
@@ -209,21 +163,4 @@ func decodeEvent(data []byte) (Message, error) {
 		return eventPtr, err
 	}
 	return nil, &DecodeProtocolMessageFieldError{e.GetSeq(), "Event", "event", e.Event}
-}
-
-// Mapping of event ids and corresponding struct constructors that
-// can be passed to json.Unmarshal.
-var eventCtor = map[string]messageCtor{
-	"initialized":  func() Message { return &InitializedEvent{} },
-	"stopped":      func() Message { return &StoppedEvent{} },
-	"continued":    func() Message { return &ContinuedEvent{} },
-	"exited":       func() Message { return &ExitedEvent{} },
-	"terminated":   func() Message { return &TerminatedEvent{} },
-	"thread":       func() Message { return &ThreadEvent{} },
-	"output":       func() Message { return &OutputEvent{} },
-	"breakpoint":   func() Message { return &BreakpointEvent{} },
-	"module":       func() Message { return &ModuleEvent{} },
-	"loadedSource": func() Message { return &LoadedSourceEvent{} },
-	"process":      func() Message { return &ProcessEvent{} },
-	"capabilities": func() Message { return &CapabilitiesEvent{} },
 }

--- a/schematypes.go
+++ b/schematypes.go
@@ -1901,3 +1901,71 @@ type DisassembledInstruction struct {
 
 // InvalidatedAreas: Logical areas that can be invalidated by the 'invalidated' event.
 type InvalidatedAreas string
+
+// Mapping of response commands and corresponding struct constructors that
+// can be passed to json.Unmarshal.
+var responseCtor = map[string]messageCtor{
+	"cancel":                    func() Message { return &CancelResponse{} },
+	"runInTerminal":             func() Message { return &RunInTerminalResponse{} },
+	"initialize":                func() Message { return &InitializeResponse{} },
+	"configurationDone":         func() Message { return &ConfigurationDoneResponse{} },
+	"launch":                    func() Message { return &LaunchResponse{} },
+	"attach":                    func() Message { return &AttachResponse{} },
+	"restart":                   func() Message { return &RestartResponse{} },
+	"disconnect":                func() Message { return &DisconnectResponse{} },
+	"terminate":                 func() Message { return &TerminateResponse{} },
+	"breakpointLocations":       func() Message { return &BreakpointLocationsResponse{} },
+	"setBreakpoints":            func() Message { return &SetBreakpointsResponse{} },
+	"setFunctionBreakpoints":    func() Message { return &SetFunctionBreakpointsResponse{} },
+	"setExceptionBreakpoints":   func() Message { return &SetExceptionBreakpointsResponse{} },
+	"dataBreakpointInfo":        func() Message { return &DataBreakpointInfoResponse{} },
+	"setDataBreakpoints":        func() Message { return &SetDataBreakpointsResponse{} },
+	"setInstructionBreakpoints": func() Message { return &SetInstructionBreakpointsResponse{} },
+	"continue":                  func() Message { return &ContinueResponse{} },
+	"next":                      func() Message { return &NextResponse{} },
+	"stepIn":                    func() Message { return &StepInResponse{} },
+	"stepOut":                   func() Message { return &StepOutResponse{} },
+	"stepBack":                  func() Message { return &StepBackResponse{} },
+	"reverseContinue":           func() Message { return &ReverseContinueResponse{} },
+	"restartFrame":              func() Message { return &RestartFrameResponse{} },
+	"goto":                      func() Message { return &GotoResponse{} },
+	"pause":                     func() Message { return &PauseResponse{} },
+	"stackTrace":                func() Message { return &StackTraceResponse{} },
+	"scopes":                    func() Message { return &ScopesResponse{} },
+	"variables":                 func() Message { return &VariablesResponse{} },
+	"setVariable":               func() Message { return &SetVariableResponse{} },
+	"source":                    func() Message { return &SourceResponse{} },
+	"threads":                   func() Message { return &ThreadsResponse{} },
+	"terminateThreads":          func() Message { return &TerminateThreadsResponse{} },
+	"modules":                   func() Message { return &ModulesResponse{} },
+	"loadedSources":             func() Message { return &LoadedSourcesResponse{} },
+	"evaluate":                  func() Message { return &EvaluateResponse{} },
+	"setExpression":             func() Message { return &SetExpressionResponse{} },
+	"stepInTargets":             func() Message { return &StepInTargetsResponse{} },
+	"gotoTargets":               func() Message { return &GotoTargetsResponse{} },
+	"completions":               func() Message { return &CompletionsResponse{} },
+	"exceptionInfo":             func() Message { return &ExceptionInfoResponse{} },
+	"readMemory":                func() Message { return &ReadMemoryResponse{} },
+	"disassemble":               func() Message { return &DisassembleResponse{} },
+}
+
+// Mapping of event ids and corresponding struct constructors that
+// can be passed to json.Unmarshal.
+var eventCtor = map[string]messageCtor{
+	"initialized":    func() Message { return &InitializedEvent{} },
+	"stopped":        func() Message { return &StoppedEvent{} },
+	"continued":      func() Message { return &ContinuedEvent{} },
+	"exited":         func() Message { return &ExitedEvent{} },
+	"terminated":     func() Message { return &TerminatedEvent{} },
+	"thread":         func() Message { return &ThreadEvent{} },
+	"output":         func() Message { return &OutputEvent{} },
+	"breakpoint":     func() Message { return &BreakpointEvent{} },
+	"module":         func() Message { return &ModuleEvent{} },
+	"loadedSource":   func() Message { return &LoadedSourceEvent{} },
+	"process":        func() Message { return &ProcessEvent{} },
+	"capabilities":   func() Message { return &CapabilitiesEvent{} },
+	"progressStart":  func() Message { return &ProgressStartEvent{} },
+	"progressUpdate": func() Message { return &ProgressUpdateEvent{} },
+	"progressEnd":    func() Message { return &ProgressEndEvent{} },
+	"invalidated":    func() Message { return &InvalidatedEvent{} },
+}

--- a/schematypes.go
+++ b/schematypes.go
@@ -1902,6 +1902,61 @@ type DisassembledInstruction struct {
 // InvalidatedAreas: Logical areas that can be invalidated by the 'invalidated' event.
 type InvalidatedAreas string
 
+// Mapping of request commands and corresponding struct constructors that
+// can be passed to json.Unmarshal.
+var requestCtor = map[string]messageCtor{
+	"cancel":        func() Message { return &CancelRequest{} },
+	"runInTerminal": func() Message { return &RunInTerminalRequest{} },
+	"initialize": func() Message {
+		return &InitializeRequest{
+			Arguments: InitializeRequestArguments{
+				// Set the default values specified here: https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Initialize.
+				LinesStartAt1:   true,
+				ColumnsStartAt1: true,
+				PathFormat:      "path",
+			}}
+	},
+	"configurationDone":         func() Message { return &ConfigurationDoneRequest{} },
+	"launch":                    func() Message { return &LaunchRequest{} },
+	"attach":                    func() Message { return &AttachRequest{} },
+	"restart":                   func() Message { return &RestartRequest{} },
+	"disconnect":                func() Message { return &DisconnectRequest{} },
+	"terminate":                 func() Message { return &TerminateRequest{} },
+	"breakpointLocations":       func() Message { return &BreakpointLocationsRequest{} },
+	"setBreakpoints":            func() Message { return &SetBreakpointsRequest{} },
+	"setFunctionBreakpoints":    func() Message { return &SetFunctionBreakpointsRequest{} },
+	"setExceptionBreakpoints":   func() Message { return &SetExceptionBreakpointsRequest{} },
+	"dataBreakpointInfo":        func() Message { return &DataBreakpointInfoRequest{} },
+	"setDataBreakpoints":        func() Message { return &SetDataBreakpointsRequest{} },
+	"setInstructionBreakpoints": func() Message { return &SetInstructionBreakpointsRequest{} },
+	"continue":                  func() Message { return &ContinueRequest{} },
+	"next":                      func() Message { return &NextRequest{} },
+	"stepIn":                    func() Message { return &StepInRequest{} },
+	"stepOut":                   func() Message { return &StepOutRequest{} },
+	"stepBack":                  func() Message { return &StepBackRequest{} },
+	"reverseContinue":           func() Message { return &ReverseContinueRequest{} },
+	"restartFrame":              func() Message { return &RestartFrameRequest{} },
+	"goto":                      func() Message { return &GotoRequest{} },
+	"pause":                     func() Message { return &PauseRequest{} },
+	"stackTrace":                func() Message { return &StackTraceRequest{} },
+	"scopes":                    func() Message { return &ScopesRequest{} },
+	"variables":                 func() Message { return &VariablesRequest{} },
+	"setVariable":               func() Message { return &SetVariableRequest{} },
+	"source":                    func() Message { return &SourceRequest{} },
+	"threads":                   func() Message { return &ThreadsRequest{} },
+	"terminateThreads":          func() Message { return &TerminateThreadsRequest{} },
+	"modules":                   func() Message { return &ModulesRequest{} },
+	"loadedSources":             func() Message { return &LoadedSourcesRequest{} },
+	"evaluate":                  func() Message { return &EvaluateRequest{} },
+	"setExpression":             func() Message { return &SetExpressionRequest{} },
+	"stepInTargets":             func() Message { return &StepInTargetsRequest{} },
+	"gotoTargets":               func() Message { return &GotoTargetsRequest{} },
+	"completions":               func() Message { return &CompletionsRequest{} },
+	"exceptionInfo":             func() Message { return &ExceptionInfoRequest{} },
+	"readMemory":                func() Message { return &ReadMemoryRequest{} },
+	"disassemble":               func() Message { return &DisassembleRequest{} },
+}
+
 // Mapping of response commands and corresponding struct constructors that
 // can be passed to json.Unmarshal.
 var responseCtor = map[string]messageCtor{

--- a/schematypes.go
+++ b/schematypes.go
@@ -1967,7 +1967,8 @@ var requestCtor = map[string]messageCtor{
 				LinesStartAt1:   true,
 				ColumnsStartAt1: true,
 				PathFormat:      "path",
-			}}
+			},
+		}
 	},
 	"configurationDone":         func() Message { return &ConfigurationDoneRequest{} },
 	"launch":                    func() Message { return &LaunchRequest{} },
@@ -2007,6 +2008,7 @@ var requestCtor = map[string]messageCtor{
 	"completions":               func() Message { return &CompletionsRequest{} },
 	"exceptionInfo":             func() Message { return &ExceptionInfoRequest{} },
 	"readMemory":                func() Message { return &ReadMemoryRequest{} },
+	"writeMemory":               func() Message { return &WriteMemoryRequest{} },
 	"disassemble":               func() Message { return &DisassembleRequest{} },
 }
 
@@ -2054,6 +2056,7 @@ var responseCtor = map[string]messageCtor{
 	"completions":               func() Message { return &CompletionsResponse{} },
 	"exceptionInfo":             func() Message { return &ExceptionInfoResponse{} },
 	"readMemory":                func() Message { return &ReadMemoryResponse{} },
+	"writeMemory":               func() Message { return &WriteMemoryResponse{} },
 	"disassemble":               func() Message { return &DisassembleResponse{} },
 }
 
@@ -2076,4 +2079,5 @@ var eventCtor = map[string]messageCtor{
 	"progressUpdate": func() Message { return &ProgressUpdateEvent{} },
 	"progressEnd":    func() Message { return &ProgressEndEvent{} },
 	"invalidated":    func() Message { return &InvalidatedEvent{} },
+	"memory":         func() Message { return &MemoryEvent{} },
 }


### PR DESCRIPTION
The mapping from event / response id to event and response types
can be done in generating. This makes sure that the maps stay up
to date with the spec.