### PR TITLE
Make `Source` field in `Breakpoint` events optional

### DIFF
--- a/cmd/gentypes/gentypes.go
+++ b/cmd/gentypes/gentypes.go
@@ -62,10 +62,10 @@ func goFieldName(jsonPropName string) string {
 // parsePropertyType takes the JSON value of a property field and extracts
 // the Go type of the property. For example, given this map:
 //
-//  {
-//    "type": "string",
-//    "description": "The command to execute."
-//  },
+//	{
+//	  "type": "string",
+//	  "description": "The command to execute."
+//	},
 //
 // It will emit "string".
 func parsePropertyType(propValue map[string]interface{}) string {
@@ -132,8 +132,8 @@ func parsePropertyType(propValue map[string]interface{}) string {
 //
 // Example:
 //
-//    "allOf": [ { "$ref": "#/definitions/ProtocolMessage" },
-//               {... type description ...} ]
+//	"allOf": [ { "$ref": "#/definitions/ProtocolMessage" },
+//	           {... type description ...} ]
 //
 // Returns base type ProtocolMessage and a map representing type description.
 // If there is no "allOf", returns an empty baseTypeName and descMap itself.
@@ -318,8 +318,13 @@ func emitToplevelType(typeName string, descJson json.RawMessage) string {
 			} else {
 				jsonTag += ",omitempty\"`"
 			}
-
+			if typeName == "Breakpoint" && goType == "Source" {
+				// Make the Source field in Breakpoint a pointer since a DAP client may distinguish
+				// between zero and nil source values.
+				goType = "*" + goType
+			}
 			fmt.Fprintf(&b, "\t%s %s %s\n", goFieldName(propName), goType, jsonTag)
+
 		}
 	}
 

--- a/schematypes.go
+++ b/schematypes.go
@@ -1827,16 +1827,16 @@ type InstructionBreakpoint struct {
 
 // Breakpoint: Information about a Breakpoint created in setBreakpoints, setFunctionBreakpoints, setInstructionBreakpoints, or setDataBreakpoints.
 type Breakpoint struct {
-	Id                   int    `json:"id,omitempty"`
-	Verified             bool   `json:"verified"`
-	Message              string `json:"message,omitempty"`
-	Source               Source `json:"source,omitempty"`
-	Line                 int    `json:"line,omitempty"`
-	Column               int    `json:"column,omitempty"`
-	EndLine              int    `json:"endLine,omitempty"`
-	EndColumn            int    `json:"endColumn,omitempty"`
-	InstructionReference string `json:"instructionReference,omitempty"`
-	Offset               int    `json:"offset,omitempty"`
+	Id                   int     `json:"id,omitempty"`
+	Verified             bool    `json:"verified"`
+	Message              string  `json:"message,omitempty"`
+	Source               *Source `json:"source,omitempty"`
+	Line                 int     `json:"line,omitempty"`
+	Column               int     `json:"column,omitempty"`
+	EndLine              int     `json:"endLine,omitempty"`
+	EndColumn            int     `json:"endColumn,omitempty"`
+	InstructionReference string  `json:"instructionReference,omitempty"`
+	Offset               int     `json:"offset,omitempty"`
 }
 
 // SteppingGranularity: The granularity of one 'step' in the stepping requests 'next', 'stepIn', 'stepOut', and 'stepBack'.


### PR DESCRIPTION
Currently, an empty breakpoint contains a `"source"` field with an empty object:

```go
data, _ := json.Marshal(dap.Breakpoint{})
fmt.Println(string(data))

// {"verified":false,"source":{}}
//                     ^^^^^^^^
```

This means that `BreakpointEvent` types with missing source are serialised with an empty source object, which clears the breakpoint location in the UI.

This change makes the `"source"` field optional, so that an empty breakpoint serialises as:

```go
data, _ := json.Marshal(dap.Breakpoint{})
fmt.Println(string(data))

// {"verified":false}
```

Fixes #66