### PR TITLE
Add a new `Codec` type that allows to register custom DAP commands

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -66,7 +66,7 @@ func NewCodec() *Codec {
 }
 
 // RegisterRequest registers a new custom DAP command, so that it can be
-// unmarshalled by DecodeMessage. Returns an error when the event already
+// unmarshalled by DecodeMessage. Returns an error when the command already
 // exists.
 //
 // The ctor functions need to return a new instance of the underlying DAP
@@ -174,10 +174,10 @@ func (c *Codec) decodeEvent(data []byte) (Message, error) {
 	return nil, &DecodeProtocolMessageFieldError{e.GetSeq(), "Event", "event", e.Event}
 }
 
-// DecodeProtocolMessage parses the JSON-encoded data and returns the result of
-// the appropriate type within the ProtocolMessage hierarchy. If message type,
-// command, etc cannot be cast, returns DecodeProtocolMessageFieldError.
-// See also godoc for json.Unmarshal, which is used for underlying decoding.
+// DecodeProtocolMessage parses the JSON-encoded ProtocolMessage and returns
+// the message embedded in it. If message type, command, etc cannot be cast,
+// returns DecodeProtocolMessageFieldError. See also godoc for json.Unmarshal,
+// which is used for underlying decoding.
 func DecodeProtocolMessage(data []byte) (Message, error) {
 	return defaultCodec.DecodeMessage(data)
 }

--- a/codec.go
+++ b/codec.go
@@ -70,9 +70,11 @@ func NewCodec() *Codec {
 // exists.
 //
 // The ctor functions need to return a new instance of the underlying DAP
-// message type. A typical implementation looks like this:
+// message type. A typical usage looks like this:
 //
-//	func() Message { return &StoppedEvent{} }
+//	reqCtor := func() Message { return &LaunchRequest{} }
+//	respCtor := func() Message { return &LaunchResponse{} }
+//      codec.RegisterRequest("launch", reqCtor, respCtor)
 func (c *Codec) RegisterRequest(command string, requestCtor, responseCtor func() Message) error {
 	_, hasReqCtor := c.requestCtor[command]
 	_, hasRespCtor := c.responseCtor[command]
@@ -89,9 +91,10 @@ func (c *Codec) RegisterRequest(command string, requestCtor, responseCtor func()
 // exists.
 //
 // The ctor function needs to return a new instance of the underlying DAP
-// message type. A typical implementation looks like this:
+// message type. A typical usage looks like this:
 //
-//	func() Message { return &StoppedEvent{} }
+//	ctor := func() Message { return &StoppedEvent{} }
+//      codec.RegisterEvent("stopped", ctor)
 func (c *Codec) RegisterEvent(event string, ctor func() Message) error {
 	if _, hasEventCtor := c.eventCtor[event]; hasEventCtor {
 		return fmt.Errorf("event %q is already registered", event)

--- a/codec_test.go
+++ b/codec_test.go
@@ -747,47 +747,6 @@ var disassembleResponseStruct = DisassembleResponse{
 	},
 }
 
-// -------- Custom Request/Response --------
-
-type customRequest struct {
-	Request
-	Body string `json:"body"`
-}
-
-func (r *customRequest) GetRequest() *Request { return &r.Request }
-
-type customResponse struct {
-	Response
-	Body string `json:"body"`
-}
-
-func (r *customResponse) GetResponse() *Response { return &r.Response }
-
-var customRequestString = `{"seq":40,"type":"request","command":"customReq","body":"242424"}`
-var customRequestStruct = customRequest{
-	Request: *newRequest(40, "customReq"),
-	Body:    "242424",
-}
-
-var customResponseString = `{"seq":40,"type":"response","request_seq":41,"command":"customReq","success":true,"body":"424242"}`
-var customResponseStruct = customResponse{
-	Response: *newResponse(40, 41, "customReq", true),
-	Body:     "424242",
-}
-
-type customEvent struct {
-	Event
-	Body int `json:"body"`
-}
-
-func (e *customEvent) GetEvent() *Event { return &e.Event }
-
-var customEventString = `{"seq":13,"type":"event","event":"customEvt","body":42}`
-var customEventStruct = customEvent{
-	Event: *newEvent(13, "customEvt"),
-	Body:  42,
-}
-
 // -------- Events --------
 
 var initializedEventString = `{"seq":1,"type":"event","event":"initialized"}`
@@ -861,7 +820,7 @@ var capabilitiesEventStruct = CapabilitiesEvent{
 	Body:  CapabilitiesEventBody{Capabilities: Capabilities{SupportsFunctionBreakpoints: true}},
 }
 
-func Test_DecodeProtocolMessage(t *testing.T) {
+func TestDecodeProtocolMessage(t *testing.T) {
 	// Sometimes partial messages can be returned on error, but
 	// the user should not rely on those and just check err itself.
 	// Hence the test will not check those.
@@ -923,7 +882,6 @@ func Test_DecodeProtocolMessage(t *testing.T) {
 		{exceptionInfoRequestString, &exceptionInfoRequestStruct, noError},
 		{readMemoryRequestString, &readMemoryRequestStruct, noError},
 		{disassembleRequestString, &disassembleRequestStruct, noError},
-		{customRequestString, &customRequestStruct, noError},
 		// Response
 		{`{"type":"response","success":true, "seq": 77}`, msgIgnoredOnError, "Response command '' is not supported (seq: 77)"},
 		{errorResponseString, &errorResponseStruct, noError},
@@ -968,7 +926,6 @@ func Test_DecodeProtocolMessage(t *testing.T) {
 		{exceptionInfoResponseString, &exceptionInfoResponseStruct, noError},
 		{readMemoryResponseString, &readMemoryResponseStruct, noError},
 		{disassembleResponseString, &disassembleResponseStruct, noError},
-		{customResponseString, &customResponseStruct, noError},
 		// Event
 		{`{"type":"event", "seq": 8}`, msgIgnoredOnError, "Event event '' is not supported (seq: 8)"},
 		{initializedEventString, &initializedEventStruct, noError},
@@ -983,15 +940,11 @@ func Test_DecodeProtocolMessage(t *testing.T) {
 		{loadedSourceEventString, &loadedSourceEventStruct, noError},
 		{processEventString, &processEventStruct, noError},
 		{capabilitiesEventString, &capabilitiesEventStruct, noError},
-		{customEventString, &customEventStruct, noError},
 	}
 
-	codec := NewCodec()
-	codec.RegisterRequest("customReq", func() Message { return new(customRequest) }, func() Message { return new(customResponse) })
-	codec.RegisterEvent("customEvt", func() Message { return new(customEvent) })
 	for _, test := range tests {
 		t.Run(test.data, func(t *testing.T) {
-			msg, err := codec.DecodeMessage([]byte(test.data))
+			msg, err := DecodeProtocolMessage([]byte(test.data))
 			if err != nil { // Decoding error
 				if err.Error() != test.wantErr { // Was it the right error?
 					t.Errorf("got error=%#v, want %q", err, test.wantErr)
@@ -1005,6 +958,75 @@ func Test_DecodeProtocolMessage(t *testing.T) {
 				if !reflect.DeepEqual(msg, test.wantMsg) { // Check result
 					t.Errorf("\ngot message\n%s\nwant\n%s", got, want)
 				}
+			}
+		})
+	}
+}
+
+// -------- Custom Request/Response and Event --------
+
+type customRequest struct {
+	Request
+	Body string `json:"body"`
+}
+
+func (r *customRequest) GetRequest() *Request { return &r.Request }
+
+type customResponse struct {
+	Response
+	Body string `json:"body"`
+}
+
+func (r *customResponse) GetResponse() *Response { return &r.Response }
+
+var customRequestString = `{"seq":40,"type":"request","command":"customReq","body":"242424"}`
+var customRequestStruct = customRequest{
+	Request: *newRequest(40, "customReq"),
+	Body:    "242424",
+}
+
+var customResponseString = `{"seq":40,"type":"response","request_seq":41,"command":"customReq","success":true,"body":"424242"}`
+var customResponseStruct = customResponse{
+	Response: *newResponse(40, 41, "customReq", true),
+	Body:     "424242",
+}
+
+type customEvent struct {
+	Event
+	Body int `json:"body"`
+}
+
+func (e *customEvent) GetEvent() *Event { return &e.Event }
+
+var customEventString = `{"seq":13,"type":"event","event":"customEvt","body":42}`
+var customEventStruct = customEvent{
+	Event: *newEvent(13, "customEvt"),
+	Body:  42,
+}
+
+func TestDecodeProtocolMessage_Custom(t *testing.T) {
+	tests := []struct {
+		data    string
+		wantMsg Message
+	}{
+		{customRequestString, &customRequestStruct},
+		{customResponseString, &customResponseStruct},
+		{customEventString, &customEventStruct},
+	}
+
+	codec := NewCodec()
+	codec.RegisterRequest("customReq", func() Message { return new(customRequest) }, func() Message { return new(customResponse) })
+	codec.RegisterEvent("customEvt", func() Message { return new(customEvent) })
+	for _, test := range tests {
+		t.Run(test.data, func(t *testing.T) {
+			msg, err := codec.DecodeMessage([]byte(test.data))
+			if err != nil { // Decoding error
+				t.Fatalf("codec.DecodeMessage() failed with %v", err)
+			}
+			got, _ := json.Marshal(msg)
+			want, _ := json.Marshal(test.wantMsg)
+			if !reflect.DeepEqual(msg, test.wantMsg) { // Check result
+				t.Errorf("\ngot message\n%s\nwant\n%s", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
Right now, go-dap supports vanilla DAP types, but it falls short when used for custom request types. This PR adds the `Codec` type with which users can register new DAP messages. After registering the new type, `Codec` can also deserialize the custom DAP message.

Custom DAP messages still need to implement the dap.Message interface.

Fixes #69