### PR TITLE
Update to latest spec

### DIFF
--- a/cmd/gentypes/debugProtocol.json
+++ b/cmd/gentypes/debugProtocol.json
@@ -14,7 +14,7 @@
 			"properties": {
 				"seq": {
 					"type": "integer",
-					"description": "Sequence number (also known as message ID). For protocol messages of type 'request' this ID can be used to cancel the request."
+					"description": "Sequence number of the message (also known as message ID). The `seq` for the first message sent by a client or debug adapter is 1, and for each subsequent message is 1 greater than the previous message sent by that actor. `seq` can be used to order requests, responses, and events, and to associate requests with their corresponding responses. For protocol messages of type `request` the sequence number can be used to cancel the request."
 				},
 				"type": {
 					"type": "string",
@@ -84,7 +84,7 @@
 					},
 					"success": {
 						"type": "boolean",
-						"description": "Outcome of the request.\nIf true, the request was successful and the 'body' attribute may contain the result of the request.\nIf the value is false, the attribute 'message' contains the error in short form and the 'body' may contain additional information (see 'ErrorResponse.body.error')."
+						"description": "Outcome of the request.\nIf true, the request was successful and the `body` attribute may contain the result of the request.\nIf the value is false, the attribute `message` contains the error in short form and the `body` may contain additional information (see `ErrorResponse.body.error`)."
 					},
 					"command": {
 						"type": "string",
@@ -92,15 +92,16 @@
 					},
 					"message": {
 						"type": "string",
-						"description": "Contains the raw error in short form if 'success' is false.\nThis raw error might be interpreted by the frontend and is not shown in the UI.\nSome predefined values exist.",
-						"_enum": [ "cancelled" ],
+						"description": "Contains the raw error in short form if `success` is false.\nThis raw error might be interpreted by the client and is not shown in the UI.\nSome predefined values exist.",
+						"_enum": [ "cancelled", "notStopped" ],
 						"enumDescriptions": [
-							"request was cancelled."
+							"the request was cancelled.",
+							"the request may be retried once the adapter is in a 'stopped' state."
 						]
 					},
 					"body": {
 						"type": [ "array", "boolean", "integer", "null", "number" , "object", "string" ],
-						"description": "Contains request result if success is true and optional error details if success is false."
+						"description": "Contains request result if success is true and error details if success is false."
 					}
 				},
 				"required": [ "type", "request_seq", "success", "command" ]
@@ -110,14 +111,14 @@
 		"ErrorResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "On error (whenever 'success' is false), the body can provide more details.",
+				"description": "On error (whenever `success` is false), the body can provide more details.",
 				"properties": {
 					"body": {
 						"type": "object",
 						"properties": {
 							"error": {
 								"$ref": "#/definitions/Message",
-								"description": "An optional, structured error message."
+								"description": "A structured error message."
 							}
 						}
 					}
@@ -129,7 +130,7 @@
 		"CancelRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The 'cancel' request is used by the frontend in two situations:\n- to indicate that it is no longer interested in the result produced by a specific request issued earlier\n- to cancel a progress sequence. Clients should only call this request if the capability 'supportsCancelRequest' is true.\nThis request has a hint characteristic: a debug adapter can only be expected to make a 'best effort' in honouring this request but there are no guarantees.\nThe 'cancel' request may return an error if it could not cancel an operation but a frontend should refrain from presenting this error to end users.\nA frontend client should only call this request if the capability 'supportsCancelRequest' is true.\nThe request that got canceled still needs to send a response back. This can either be a normal result ('success' attribute true)\nor an error response ('success' attribute false and the 'message' set to 'cancelled').\nReturning partial results from a cancelled request is possible but please note that a frontend client has no generic way for detecting that a response is partial or not.\n The progress that got cancelled still needs to send a 'progressEnd' event back.\n A client should not assume that progress just got cancelled after sending the 'cancel' request.",
+				"description": "The `cancel` request is used by the client in two situations:\n- to indicate that it is no longer interested in the result produced by a specific request issued earlier\n- to cancel a progress sequence. Clients should only call this request if the corresponding capability `supportsCancelRequest` is true.\nThis request has a hint characteristic: a debug adapter can only be expected to make a 'best effort' in honoring this request but there are no guarantees.\nThe `cancel` request may return an error if it could not cancel an operation but a client should refrain from presenting this error to end users.\nThe request that got cancelled still needs to send a response back. This can either be a normal result (`success` attribute true) or an error response (`success` attribute false and the `message` set to `cancelled`).\nReturning partial results from a cancelled request is possible but please note that a client has no generic way for detecting that a response is partial or not.\nThe progress that got cancelled still needs to send a `progressEnd` event back.\n A client should not assume that progress just got cancelled after sending the `cancel` request.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -144,22 +145,22 @@
 		},
 		"CancelArguments": {
 			"type": "object",
-			"description": "Arguments for 'cancel' request.",
+			"description": "Arguments for `cancel` request.",
 			"properties": {
 				"requestId": {
 					"type": "integer",
-					"description": "The ID (attribute 'seq') of the request to cancel. If missing no request is cancelled.\nBoth a 'requestId' and a 'progressId' can be specified in one request."
+					"description": "The ID (attribute `seq`) of the request to cancel. If missing no request is cancelled.\nBoth a `requestId` and a `progressId` can be specified in one request."
 				},
 				"progressId": {
 					"type": "string",
-					"description": "The ID (attribute 'progressId') of the progress to cancel. If missing no progress is cancelled.\nBoth a 'requestId' and a 'progressId' can be specified in one request."
+					"description": "The ID (attribute `progressId`) of the progress to cancel. If missing no progress is cancelled.\nBoth a `requestId` and a `progressId` can be specified in one request."
 				}
 			}
 		},
 		"CancelResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'cancel' request. This is just an acknowledgement, so no body field is required."
+				"description": "Response to `cancel` request. This is just an acknowledgement, so no body field is required."
 			}]
 		},
 
@@ -167,7 +168,7 @@
 			"allOf": [ { "$ref": "#/definitions/Event" }, {
 				"type": "object",
 				"title": "Events",
-				"description": "This event indicates that the debug adapter is ready to accept configuration requests (e.g. SetBreakpointsRequest, SetExceptionBreakpointsRequest).\nA debug adapter is expected to send this event when it is ready to accept configuration requests (but not before the 'initialize' request has finished).\nThe sequence of events/requests is as follows:\n- adapters sends 'initialized' event (after the 'initialize' request has returned)\n- frontend sends zero or more 'setBreakpoints' requests\n- frontend sends one 'setFunctionBreakpoints' request (if capability 'supportsFunctionBreakpoints' is true)\n- frontend sends a 'setExceptionBreakpoints' request if one or more 'exceptionBreakpointFilters' have been defined (or if 'supportsConfigurationDoneRequest' is not defined or false)\n- frontend sends other future configuration requests\n- frontend sends one 'configurationDone' request to indicate the end of the configuration.",
+				"description": "This event indicates that the debug adapter is ready to accept configuration requests (e.g. `setBreakpoints`, `setExceptionBreakpoints`).\nA debug adapter is expected to send this event when it is ready to accept configuration requests (but not before the `initialize` request has finished).\nThe sequence of events/requests is as follows:\n- adapters sends `initialized` event (after the `initialize` request has returned)\n- client sends zero or more `setBreakpoints` requests\n- client sends one `setFunctionBreakpoints` request (if corresponding capability `supportsFunctionBreakpoints` is true)\n- client sends a `setExceptionBreakpoints` request if one or more `exceptionBreakpointFilters` have been defined (or if `supportsConfigurationDoneRequest` is not true)\n- client sends other future configuration requests\n- client sends one `configurationDone` request to indicate the end of the configuration.",
 				"properties": {
 					"event": {
 						"type": "string",
@@ -181,7 +182,7 @@
 		"StoppedEvent": {
 			"allOf": [ { "$ref": "#/definitions/Event" }, {
 				"type": "object",
-				"description": "The event indicates that the execution of the debuggee has stopped due to some condition.\nThis can be caused by a break point previously set, a stepping request has completed, by executing a debugger statement etc.",
+				"description": "The event indicates that the execution of the debuggee has stopped due to some condition.\nThis can be caused by a breakpoint previously set, a stepping request has completed, by executing a debugger statement etc.",
 				"properties": {
 					"event": {
 						"type": "string",
@@ -192,12 +193,12 @@
 						"properties": {
 							"reason": {
 								"type": "string",
-								"description": "The reason for the event.\nFor backward compatibility this string is shown in the UI if the 'description' attribute is missing (but it must not be translated).",
+								"description": "The reason for the event.\nFor backward compatibility this string is shown in the UI if the `description` attribute is missing (but it must not be translated).",
 								"_enum": [ "step", "breakpoint", "exception", "pause", "entry", "goto", "function breakpoint", "data breakpoint", "instruction breakpoint" ]
 							},
 							"description": {
 								"type": "string",
-								"description": "The full reason for the event, e.g. 'Paused on exception'. This string is shown in the UI as is and must be translated."
+								"description": "The full reason for the event, e.g. 'Paused on exception'. This string is shown in the UI as is and can be translated."
 							},
 							"threadId": {
 								"type": "integer",
@@ -205,22 +206,22 @@
 							},
 							"preserveFocusHint": {
 								"type": "boolean",
-								"description": "A value of true hints to the frontend that this event should not change the focus."
+								"description": "A value of true hints to the client that this event should not change the focus."
 							},
 							"text": {
 								"type": "string",
-								"description": "Additional information. E.g. if reason is 'exception', text contains the exception name. This string is shown in the UI."
+								"description": "Additional information. E.g. if reason is `exception`, text contains the exception name. This string is shown in the UI."
 							},
 							"allThreadsStopped": {
 								"type": "boolean",
-								"description": "If 'allThreadsStopped' is true, a debug adapter can announce that all threads have stopped.\n- The client should use this information to enable that all threads can be expanded to access their stacktraces.\n- If the attribute is missing or false, only the thread with the given threadId can be expanded."
+								"description": "If `allThreadsStopped` is true, a debug adapter can announce that all threads have stopped.\n- The client should use this information to enable that all threads can be expanded to access their stacktraces.\n- If the attribute is missing or false, only the thread with the given `threadId` can be expanded."
 							},
 							"hitBreakpointIds": {
 								"type": "array",
 								"items": {
 									"type": "integer"
 								},
-								"description": "Ids of the breakpoints that triggered the event. In most cases there will be only a single breakpoint but here are some examples for multiple breakpoints:\n- Different types of breakpoints map to the same location.\n- Multiple source breakpoints get collapsed to the same instruction by the compiler/runtime.\n- Multiple function breakpoints with different function names map to the same location."
+								"description": "Ids of the breakpoints that triggered the event. In most cases there is only a single breakpoint but here are some examples for multiple breakpoints:\n- Different types of breakpoints map to the same location.\n- Multiple source breakpoints get collapsed to the same instruction by the compiler/runtime.\n- Multiple function breakpoints with different function names map to the same location."
 							}
 						},
 						"required": [ "reason" ]
@@ -233,7 +234,7 @@
 		"ContinuedEvent": {
 			"allOf": [ { "$ref": "#/definitions/Event" }, {
 				"type": "object",
-				"description": "The event indicates that the execution of the debuggee has continued.\nPlease note: a debug adapter is not expected to send this event in response to a request that implies that execution continues, e.g. 'launch' or 'continue'.\nIt is only necessary to send a 'continued' event if there was no previous request that implied this.",
+				"description": "The event indicates that the execution of the debuggee has continued.\nPlease note: a debug adapter is not expected to send this event in response to a request that implies that execution continues, e.g. `launch` or `continue`.\nIt is only necessary to send a `continued` event if there was no previous request that implied this.",
 				"properties": {
 					"event": {
 						"type": "string",
@@ -248,7 +249,7 @@
 							},
 							"allThreadsContinued": {
 								"type": "boolean",
-								"description": "If 'allThreadsContinued' is true, a debug adapter can announce that all threads have continued."
+								"description": "If `allThreadsContinued` is true, a debug adapter can announce that all threads have continued."
 							}
 						},
 						"required": [ "threadId" ]
@@ -296,7 +297,7 @@
 						"properties": {
 							"restart": {
 								"type": [ "array", "boolean", "integer", "null", "number", "object", "string" ],
-								"description": "A debug adapter may set 'restart' to true (or to an arbitrary object) to request that the front end restarts the session.\nThe value is not interpreted by the client and passed unmodified as an attribute '__restart' to the 'launch' and 'attach' requests."
+								"description": "A debug adapter may set `restart` to true (or to an arbitrary object) to request that the client restarts the session.\nThe value is not interpreted by the client and passed unmodified as an attribute `__restart` to the `launch` and `attach` requests."
 							}
 						}
 					}
@@ -348,8 +349,15 @@
 						"properties": {
 							"category": {
 								"type": "string",
-								"description": "The output category. If not specified, 'console' is assumed.",
-								"_enum": [ "console", "stdout", "stderr", "telemetry" ]
+								"description": "The output category. If not specified or if the category is not understood by the client, `console` is assumed.",
+								"_enum": [ "console", "important", "stdout", "stderr", "telemetry" ],
+								"enumDescriptions": [
+									"Show the output in the client's default message UI, e.g. a 'debug console'. This category should only be used for informational output from the debugger (as opposed to the debuggee).",
+									"A hint for the client to show the output in the client's UI for important and highly visible information, e.g. as a popup notification. This category should only be used for important messages from the debugger (as opposed to the debuggee). Since this category value is a hint, clients might ignore the hint and assume the `console` category.",
+									"Show the output as normal program output from the debuggee.",
+									"Show the output as error program output from the debuggee.",
+									"Send the output to telemetry instead of showing it to the user."
+								]
 							},
 							"output": {
 								"type": "string",
@@ -360,30 +368,30 @@
 								"description": "Support for keeping an output log organized by grouping related messages.",
 								"enum": [ "start", "startCollapsed", "end" ],
 								"enumDescriptions": [
-									"Start a new group in expanded mode. Subsequent output events are members of the group and should be shown indented.\nThe 'output' attribute becomes the name of the group and is not indented.",
-									"Start a new group in collapsed mode. Subsequent output events are members of the group and should be shown indented (as soon as the group is expanded).\nThe 'output' attribute becomes the name of the group and is not indented.",
-									"End the current group and decreases the indentation of subsequent output events.\nA non empty 'output' attribute is shown as the unindented end of the group."
+									"Start a new group in expanded mode. Subsequent output events are members of the group and should be shown indented.\nThe `output` attribute becomes the name of the group and is not indented.",
+									"Start a new group in collapsed mode. Subsequent output events are members of the group and should be shown indented (as soon as the group is expanded).\nThe `output` attribute becomes the name of the group and is not indented.",
+									"End the current group and decrease the indentation of subsequent output events.\nA non-empty `output` attribute is shown as the unindented end of the group."
 								]
 							},
 							"variablesReference": {
 								"type": "integer",
-								"description": "If an attribute 'variablesReference' exists and its value is > 0, the output contains objects which can be retrieved by passing 'variablesReference' to the 'variables' request. The value should be less than or equal to 2147483647 (2^31-1)."
+								"description": "If an attribute `variablesReference` exists and its value is > 0, the output contains objects which can be retrieved by passing `variablesReference` to the `variables` request as long as execution remains suspended. See 'Lifetime of Object References' in the Overview section for details."
 							},
 							"source": {
 								"$ref": "#/definitions/Source",
-								"description": "An optional source location where the output was produced."
+								"description": "The source location where the output was produced."
 							},
 							"line": {
 								"type": "integer",
-								"description": "An optional source location line where the output was produced."
+								"description": "The source location's line where the output was produced."
 							},
 							"column": {
 								"type": "integer",
-								"description": "An optional source location column where the output was produced."
+								"description": "The position in `line` where the output was produced. It is measured in UTF-16 code units and the client capability `columnsStartAt1` determines whether it is 0- or 1-based."
 							},
 							"data": {
 								"type": [ "array", "boolean", "integer", "null", "number" , "object", "string" ],
-								"description": "Optional data to report. For the 'telemetry' category the data will be sent to telemetry, for the other categories the data is shown in JSON format."
+								"description": "Additional data to report. For the `telemetry` category the data is sent to telemetry, for the other categories the data is shown in JSON format."
 							}
 						},
 						"required": ["output"]
@@ -412,7 +420,7 @@
 							},
 							"breakpoint": {
 								"$ref": "#/definitions/Breakpoint",
-								"description": "The 'id' attribute is used to find the target breakpoint and the other attributes are used as the new values."
+								"description": "The `id` attribute is used to find the target breakpoint, the other attributes are used as the new values."
 							}
 						},
 						"required": [ "reason", "breakpoint" ]
@@ -441,7 +449,7 @@
 							},
 							"module": {
 								"$ref": "#/definitions/Module",
-								"description": "The new, changed, or removed module. In case of 'removed' only the module id is used."
+								"description": "The new, changed, or removed module. In case of `removed` only the module id is used."
 							}
 						},
 						"required": [ "reason", "module" ]
@@ -500,7 +508,7 @@
 								},
 								"systemProcessId": {
 									"type": "integer",
-									"description": "The system process id of the debugged process. This property will be missing for non-system processes."
+									"description": "The system process id of the debugged process. This property is missing for non-system processes."
 								},
 								"isLocalProcess": {
 									"type": "boolean",
@@ -532,7 +540,7 @@
 		"CapabilitiesEvent": {
 			"allOf": [ { "$ref": "#/definitions/Event" }, {
 				"type": "object",
-				"description": "The event indicates that one or more capabilities have changed.\nSince the capabilities are dependent on the frontend and its UI, it might not be possible to change that at random times (or too late).\nConsequently this event has a hint characteristic: a frontend can only be expected to make a 'best effort' in honouring individual capabilities but there are no guarantees.\nOnly changed capabilities need to be included, all other capabilities keep their values.",
+				"description": "The event indicates that one or more capabilities have changed.\nSince the capabilities are dependent on the client and its UI, it might not be possible to change that at random times (or too late).\nConsequently this event has a hint characteristic: a client can only be expected to make a 'best effort' in honoring individual capabilities but there are no guarantees.\nOnly changed capabilities need to be included, all other capabilities keep their values.",
 				"properties": {
 					"event": {
 						"type": "string",
@@ -556,7 +564,7 @@
 		"ProgressStartEvent": {
 			"allOf": [ { "$ref": "#/definitions/Event" }, {
 				"type": "object",
-				"description": "The event signals that a long running operation is about to start and\nprovides additional information for the client to set up a corresponding progress and cancellation UI.\nThe client is free to delay the showing of the UI in order to reduce flicker.\nThis event should only be sent if the client has passed the value true for the 'supportsProgressReporting' capability of the 'initialize' request.",
+				"description": "The event signals that a long running operation is about to start and provides additional information for the client to set up a corresponding progress and cancellation UI.\nThe client is free to delay the showing of the UI in order to reduce flicker.\nThis event should only be sent if the corresponding capability `supportsProgressReporting` is true.",
 				"properties": {
 					"event": {
 						"type": "string",
@@ -567,27 +575,27 @@
 						"properties": {
 							"progressId": {
 								"type": "string",
-								"description": "An ID that must be used in subsequent 'progressUpdate' and 'progressEnd' events to make them refer to the same progress reporting.\nIDs must be unique within a debug session."
+								"description": "An ID that can be used in subsequent `progressUpdate` and `progressEnd` events to make them refer to the same progress reporting.\nIDs must be unique within a debug session."
 							},
 							"title": {
 								"type": "string",
-								"description": "Mandatory (short) title of the progress reporting. Shown in the UI to describe the long running operation."
+								"description": "Short title of the progress reporting. Shown in the UI to describe the long running operation."
 							},
 							"requestId": {
 								"type": "integer",
-								"description": "The request ID that this progress report is related to. If specified a debug adapter is expected to emit\nprogress events for the long running request until the request has been either completed or cancelled.\nIf the request ID is omitted, the progress report is assumed to be related to some general activity of the debug adapter."
+								"description": "The request ID that this progress report is related to. If specified a debug adapter is expected to emit progress events for the long running request until the request has been either completed or cancelled.\nIf the request ID is omitted, the progress report is assumed to be related to some general activity of the debug adapter."
 							},
 							"cancellable": {
 								"type": "boolean",
-								"description": "If true, the request that reports progress may be canceled with a 'cancel' request.\nSo this property basically controls whether the client should use UX that supports cancellation.\nClients that don't support cancellation are allowed to ignore the setting."
+								"description": "If true, the request that reports progress may be cancelled with a `cancel` request.\nSo this property basically controls whether the client should use UX that supports cancellation.\nClients that don't support cancellation are allowed to ignore the setting."
 							},
 							"message": {
 								"type": "string",
-								"description": "Optional, more detailed progress message."
+								"description": "More detailed progress message."
 							},
 							"percentage": {
 								"type": "number",
-								"description": "Optional progress percentage to display (value range: 0 to 100). If omitted no percentage will be shown."
+								"description": "Progress percentage to display (value range: 0 to 100). If omitted no percentage is shown."
 							}
 						},
 						"required": [ "progressId", "title" ]
@@ -600,7 +608,7 @@
 		"ProgressUpdateEvent": {
 			"allOf": [ { "$ref": "#/definitions/Event" }, {
 				"type": "object",
-				"description": "The event signals that the progress reporting needs to updated with a new message and/or percentage.\nThe client does not have to update the UI immediately, but the clients needs to keep track of the message and/or percentage values.\nThis event should only be sent if the client has passed the value true for the 'supportsProgressReporting' capability of the 'initialize' request.",
+				"description": "The event signals that the progress reporting needs to be updated with a new message and/or percentage.\nThe client does not have to update the UI immediately, but the clients needs to keep track of the message and/or percentage values.\nThis event should only be sent if the corresponding capability `supportsProgressReporting` is true.",
 				"properties": {
 					"event": {
 						"type": "string",
@@ -611,15 +619,15 @@
 						"properties": {
 							"progressId": {
 								"type": "string",
-								"description": "The ID that was introduced in the initial 'progressStart' event."
+								"description": "The ID that was introduced in the initial `progressStart` event."
 							},
 							"message": {
 								"type": "string",
-								"description": "Optional, more detailed progress message. If omitted, the previous message (if any) is used."
+								"description": "More detailed progress message. If omitted, the previous message (if any) is used."
 							},
 							"percentage": {
 								"type": "number",
-								"description": "Optional progress percentage to display (value range: 0 to 100). If omitted no percentage will be shown."
+								"description": "Progress percentage to display (value range: 0 to 100). If omitted no percentage is shown."
 							}
 						},
 						"required": [ "progressId" ]
@@ -632,7 +640,7 @@
 		"ProgressEndEvent": {
 			"allOf": [ { "$ref": "#/definitions/Event" }, {
 				"type": "object",
-				"description": "The event signals the end of the progress reporting with an optional final message.\nThis event should only be sent if the client has passed the value true for the 'supportsProgressReporting' capability of the 'initialize' request.",
+				"description": "The event signals the end of the progress reporting with a final message.\nThis event should only be sent if the corresponding capability `supportsProgressReporting` is true.",
 				"properties": {
 					"event": {
 						"type": "string",
@@ -643,11 +651,11 @@
 						"properties": {
 							"progressId": {
 								"type": "string",
-								"description": "The ID that was introduced in the initial 'ProgressStartEvent'."
+								"description": "The ID that was introduced in the initial `ProgressStartEvent`."
 							},
 							"message": {
 								"type": "string",
-								"description": "Optional, more detailed progress message. If omitted, the previous message (if any) is used."
+								"description": "More detailed progress message. If omitted, the previous message (if any) is used."
 							}
 						},
 						"required": [ "progressId" ]
@@ -660,7 +668,7 @@
 		"InvalidatedEvent": {
 			"allOf": [ { "$ref": "#/definitions/Event" }, {
 				"type": "object",
-				"description": "This event signals that some state in the debug adapter has changed and requires that the client needs to re-render the data snapshot previously requested.\nDebug adapters do not have to emit this event for runtime changes like stopped or thread events because in that case the client refetches the new state anyway. But the event can be used for example to refresh the UI after rendering formatting has changed in the debug adapter.\nThis event should only be sent if the debug adapter has received a value true for the 'supportsInvalidatedEvent' capability of the 'initialize' request.",
+				"description": "This event signals that some state in the debug adapter has changed and requires that the client needs to re-render the data snapshot previously requested.\nDebug adapters do not have to emit this event for runtime changes like stopped or thread events because in that case the client refetches the new state anyway. But the event can be used for example to refresh the UI after rendering formatting has changed in the debug adapter.\nThis event should only be sent if the corresponding capability `supportsInvalidatedEvent` is true.",
 				"properties": {
 					"event": {
 						"type": "string",
@@ -671,7 +679,7 @@
 						"properties": {
 							"areas": {
 								"type": "array",
-								"description": "Optional set of logical areas that got invalidated. This property has a hint characteristic: a client can only be expected to make a 'best effort' in honouring the areas but there are no guarantees. If this property is missing, empty, or if values are not understand the client should assume a single value 'all'.",
+								"description": "Set of logical areas that got invalidated. This property has a hint characteristic: a client can only be expected to make a 'best effort' in honoring the areas but there are no guarantees. If this property is missing, empty, or if values are not understood, the client should assume a single value `all`.",
 								"items": {
 									"$ref": "#/definitions/InvalidatedAreas"
 								}
@@ -682,7 +690,7 @@
 							},
 							"stackFrameId": {
 								"type": "integer",
-								"description": "If specified, the client only needs to refetch data related to this stack frame (and the 'threadId' is ignored)."
+								"description": "If specified, the client only needs to refetch data related to this stack frame (and the `threadId` is ignored)."
 							}
 						}
 					}
@@ -694,7 +702,7 @@
 		"MemoryEvent": {
 			"allOf": [ { "$ref": "#/definitions/Event" }, {
 				"type": "object",
-				"description": "This event indicates that some memory range has been updated. It should only be sent if the debug adapter has received a value true for the `supportsMemoryEvent` capability of the `initialize` request.\nClients typically react to the event by re-issuing a `readMemory` request if they show the memory identified by the `memoryReference` and if the updated memory range overlaps the displayed range. Clients should not make assumptions how individual memory references relate to each other, so they should not assume that they are part of a single continuous address range and might overlap.\nDebug adapters can use this event to indicate that the contents of a memory range has changed due to some other DAP request like `setVariable` or `setExpression`. Debug adapters are not expected to emit this event for each and every memory change of a running program, because that information is typically not available from debuggers and it would flood clients with too many events.",
+				"description": "This event indicates that some memory range has been updated. It should only be sent if the corresponding capability `supportsMemoryEvent` is true.\nClients typically react to the event by re-issuing a `readMemory` request if they show the memory identified by the `memoryReference` and if the updated memory range overlaps the displayed range. Clients should not make assumptions how individual memory references relate to each other, so they should not assume that they are part of a single continuous address range and might overlap.\nDebug adapters can use this event to indicate that the contents of a memory range has changed due to some other request like `setVariable` or `setExpression`. Debug adapters are not expected to emit this event for each and every memory change of a running program, because that information is typically not available from debuggers and it would flood clients with too many events.",
 				"properties": {
 					"event": {
 						"type": "string",
@@ -727,7 +735,7 @@
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
 				"title": "Reverse Requests",
-				"description": "This optional request is sent from the debug adapter to the client to run a command in a terminal.\nThis is typically used to launch the debuggee in a terminal provided by the client.\nThis request should only be called if the client has passed the value true for the 'supportsRunInTerminalRequest' capability of the 'initialize' request.",
+				"description": "This request is sent from the debug adapter to the client to run a command in a terminal.\nThis is typically used to launch the debuggee in a terminal provided by the client.\nThis request should only be called if the corresponding client capability `supportsRunInTerminalRequest` is true.\nClient implementations of `runInTerminal` are free to run the command however they choose including issuing the command to a command line interpreter (aka 'shell'). Argument strings passed to the `runInTerminal` request must arrive verbatim in the command to be run. As a consequence, clients which use a shell are responsible for escaping any special shell characters in the argument strings to prevent them from being interpreted (and modified) by the shell.\nSome users may wish to take advantage of shell processing in the argument strings. For clients which implement `runInTerminal` using an intermediary shell, the `argsCanBeInterpretedByShell` property can be set to true. In this case the client is requested not to escape any special shell characters in the argument strings.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -742,16 +750,16 @@
 		},
 		"RunInTerminalRequestArguments": {
 			"type": "object",
-			"description": "Arguments for 'runInTerminal' request.",
+			"description": "Arguments for `runInTerminal` request.",
 			"properties": {
 				"kind": {
 					"type": "string",
 					"enum": [ "integrated", "external" ],
-					"description": "What kind of terminal to launch."
+					"description": "What kind of terminal to launch. Defaults to `integrated` if not specified."
 				},
 				"title": {
 					"type": "string",
-					"description": "Optional title of the terminal."
+					"description": "Title of the terminal."
 				},
 				"cwd": {
 					"type": "string",
@@ -769,8 +777,12 @@
 					"description": "Environment key-value pairs that are added to or removed from the default environment.",
 					"additionalProperties": {
 						"type": [ "string", "null" ],
-						"description": "Proper values must be strings. A value of 'null' removes the variable from the environment."
+						"description": "A string is a proper value for an environment variable. The value `null` removes the variable from the environment."
 					}
+				},
+				"argsCanBeInterpretedByShell": {
+					"type": "boolean",
+					"description": "This property should only be set if the corresponding capability `supportsArgsCanBeInterpretedByShell` is true. If the client uses an intermediary shell to launch the application, then the client must not attempt to escape characters with special meanings for the shell. The user is fully responsible for escaping as needed and that arguments using special characters may not be portable across shells."
 				}
 			},
 			"required": [ "args", "cwd" ]
@@ -778,7 +790,7 @@
 		"RunInTerminalResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'runInTerminal' request.",
+				"description": "Response to `runInTerminal` request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -797,12 +809,72 @@
 				"required": [ "body" ]
 			}]
 		},
+		"StartDebuggingRequest": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/Request"
+				},
+				{
+					"type": "object",
+					"description": "This request is sent from the debug adapter to the client to start a new debug session of the same type as the caller.\nThis request should only be sent if the corresponding client capability `supportsStartDebuggingRequest` is true.\nA client implementation of `startDebugging` should start a new debug session (of the same type as the caller) in the same way that the caller's session was started. If the client supports hierarchical debug sessions, the newly created session can be treated as a child of the caller session.",
+					"properties": {
+						"command": {
+							"type": "string",
+							"enum": [
+								"startDebugging"
+							]
+						},
+						"arguments": {
+							"$ref": "#/definitions/StartDebuggingRequestArguments"
+						}
+					},
+					"required": [
+						"command",
+						"arguments"
+					]
+				}
+			]
+		},
+		"StartDebuggingRequestArguments": {
+			"type": "object",
+			"description": "Arguments for `startDebugging` request.",
+			"properties": {
+				"configuration": {
+					"type": "object",
+					"additionalProperties": true,
+					"description": "Arguments passed to the new debug session. The arguments must only contain properties understood by the `launch` or `attach` requests of the debug adapter and they must not contain any client-specific properties (e.g. `type`) or client-specific features (e.g. substitutable 'variables')."
+				},
+				"request": {
+					"type": "string",
+					"enum": [
+						"launch",
+						"attach"
+					],
+					"description": "Indicates whether the new debug session should be started with a `launch` or `attach` request."
+				}
+			},
+			"required": [
+				"configuration",
+				"request"
+			]
+		},
+		"StartDebuggingResponse": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/Response"
+				},
+				{
+					"type": "object",
+					"description": "Response to `startDebugging` request. This is just an acknowledgement, so no body field is required."
+				}
+			]
+		},
 
 		"InitializeRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
 				"title": "Requests",
-				"description": "The 'initialize' request is sent as the first request from the client to the debug adapter\nin order to configure it with client capabilities and to retrieve capabilities from the debug adapter.\nUntil the debug adapter has responded to with an 'initialize' response, the client must not send any additional requests or events to the debug adapter.\nIn addition the debug adapter is not allowed to send any requests or events to the client until it has responded with an 'initialize' response.\nThe 'initialize' request may only be sent once.",
+				"description": "The `initialize` request is sent as the first request from the client to the debug adapter in order to configure it with client capabilities and to retrieve capabilities from the debug adapter.\nUntil the debug adapter has responded with an `initialize` response, the client must not send any additional requests or events to the debug adapter.\nIn addition the debug adapter is not allowed to send any requests or events to the client until it has responded with an `initialize` response.\nThe `initialize` request may only be sent once.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -817,15 +889,15 @@
 		},
 		"InitializeRequestArguments": {
 			"type": "object",
-			"description": "Arguments for 'initialize' request.",
+			"description": "Arguments for `initialize` request.",
 			"properties": {
 				"clientID": {
 					"type": "string",
-					"description": "The ID of the (frontend) client using this adapter."
+					"description": "The ID of the client using this adapter."
 				},
 				"clientName": {
 					"type": "string",
-					"description": "The human readable name of the (frontend) client using this adapter."
+					"description": "The human-readable name of the client using this adapter."
 				},
 				"adapterID": {
 					"type": "string",
@@ -833,7 +905,7 @@
 				},
 				"locale": {
 					"type": "string",
-					"description": "The ISO-639 locale of the (frontend) client using this adapter, e.g. en-US or de-CH."
+					"description": "The ISO-639 locale of the client using this adapter, e.g. en-US or de-CH."
 				},
 				"linesStartAt1": {
 					"type": "boolean",
@@ -846,11 +918,11 @@
 				"pathFormat": {
 					"type": "string",
 					"_enum": [ "path", "uri" ],
-					"description": "Determines in what format paths are specified. The default is 'path', which is the native format."
+					"description": "Determines in what format paths are specified. The default is `path`, which is the native format."
 				},
 				"supportsVariableType": {
 					"type": "boolean",
-					"description": "Client supports the optional type attribute for variables."
+					"description": "Client supports the `type` attribute for variables."
 				},
 				"supportsVariablePaging": {
 					"type": "boolean",
@@ -858,7 +930,7 @@
 				},
 				"supportsRunInTerminalRequest": {
 					"type": "boolean",
-					"description": "Client supports the runInTerminal request."
+					"description": "Client supports the `runInTerminal` request."
 				},
 				"supportsMemoryReferences": {
 					"type": "boolean",
@@ -870,11 +942,19 @@
 				},
 				"supportsInvalidatedEvent": {
 					"type": "boolean",
-					"description": "Client supports the invalidated event."
+					"description": "Client supports the `invalidated` event."
 				},
 				"supportsMemoryEvent": {
 					"type": "boolean",
-					"description": "Client supports the memory event."
+					"description": "Client supports the `memory` event."
+				},
+				"supportsArgsCanBeInterpretedByShell": {
+					"type": "boolean",
+					"description": "Client supports the `argsCanBeInterpretedByShell` attribute on the `runInTerminal` request."
+				},
+				"supportsStartDebuggingRequest": {
+					"type": "boolean",
+					"description": "Client supports the `startDebugging` request."
 				}
 			},
 			"required": [ "adapterID" ]
@@ -882,7 +962,7 @@
 		"InitializeResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'initialize' request.",
+				"description": "Response to `initialize` request.",
 				"properties": {
 					"body": {
 						"$ref": "#/definitions/Capabilities",
@@ -895,7 +975,7 @@
 		"ConfigurationDoneRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "This optional request indicates that the client has finished initialization of the debug adapter.\nSo it is the last request in the sequence of configuration requests (which was started by the 'initialized' event).\nClients should only call this request if the capability 'supportsConfigurationDoneRequest' is true.",
+				"description": "This request indicates that the client has finished initialization of the debug adapter.\nSo it is the last request in the sequence of configuration requests (which was started by the `initialized` event).\nClients should only call this request if the corresponding capability `supportsConfigurationDoneRequest` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -910,19 +990,19 @@
 		},
 		"ConfigurationDoneArguments": {
 			"type": "object",
-			"description": "Arguments for 'configurationDone' request."
+			"description": "Arguments for `configurationDone` request."
 		},
 		"ConfigurationDoneResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'configurationDone' request. This is just an acknowledgement, so no body field is required."
+				"description": "Response to `configurationDone` request. This is just an acknowledgement, so no body field is required."
 			}]
 		},
 
 		"LaunchRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "This launch request is sent from the client to the debug adapter to start the debuggee with or without debugging (if 'noDebug' is true).\nSince launching is debugger/runtime specific, the arguments for this request are not part of this specification.",
+				"description": "This launch request is sent from the client to the debug adapter to start the debuggee with or without debugging (if `noDebug` is true).\nSince launching is debugger/runtime specific, the arguments for this request are not part of this specification.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -937,29 +1017,29 @@
 		},
 		"LaunchRequestArguments": {
 			"type": "object",
-			"description": "Arguments for 'launch' request. Additional attributes are implementation specific.",
+			"description": "Arguments for `launch` request. Additional attributes are implementation specific.",
 			"properties": {
 				"noDebug": {
 					"type": "boolean",
-					"description": "If noDebug is true the launch request should launch the program without enabling debugging."
+					"description": "If true, the launch request should launch the program without enabling debugging."
 				},
 				"__restart": {
 					"type": [ "array", "boolean", "integer", "null", "number", "object", "string" ],
-					"description": "Optional data from the previous, restarted session.\nThe data is sent as the 'restart' attribute of the 'terminated' event.\nThe client should leave the data intact."
+					"description": "Arbitrary data from the previous, restarted session.\nThe data is sent as the `restart` attribute of the `terminated` event.\nThe client should leave the data intact."
 				}
 			}
 		},
 		"LaunchResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'launch' request. This is just an acknowledgement, so no body field is required."
+				"description": "Response to `launch` request. This is just an acknowledgement, so no body field is required."
 			}]
 		},
 
 		"AttachRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The attach request is sent from the client to the debug adapter to attach to a debuggee that is already running.\nSince attaching is debugger/runtime specific, the arguments for this request are not part of this specification.",
+				"description": "The `attach` request is sent from the client to the debug adapter to attach to a debuggee that is already running.\nSince attaching is debugger/runtime specific, the arguments for this request are not part of this specification.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -974,25 +1054,25 @@
 		},
 		"AttachRequestArguments": {
 			"type": "object",
-			"description": "Arguments for 'attach' request. Additional attributes are implementation specific.",
+			"description": "Arguments for `attach` request. Additional attributes are implementation specific.",
 			"properties": {
 				"__restart": {
 					"type": [ "array", "boolean", "integer", "null", "number", "object", "string" ],
-					"description": "Optional data from the previous, restarted session.\nThe data is sent as the 'restart' attribute of the 'terminated' event.\nThe client should leave the data intact."
+					"description": "Arbitrary data from the previous, restarted session.\nThe data is sent as the `restart` attribute of the `terminated` event.\nThe client should leave the data intact."
 				}
 			}
 		},
 		"AttachResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'attach' request. This is just an acknowledgement, so no body field is required."
+				"description": "Response to `attach` request. This is just an acknowledgement, so no body field is required."
 			}]
 		},
 
 		"RestartRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Restarts a debug session. Clients should only call this request if the capability 'supportsRestartRequest' is true.\nIf the capability is missing or has the value false, a typical client will emulate 'restart' by terminating the debug adapter first and then launching it anew.",
+				"description": "Restarts a debug session. Clients should only call this request if the corresponding capability `supportsRestartRequest` is true.\nIf the capability is missing or has the value false, a typical client emulates `restart` by terminating the debug adapter first and then launching it anew.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1007,28 +1087,28 @@
 		},
 		"RestartArguments": {
 			"type": "object",
-			"description": "Arguments for 'restart' request.",
+			"description": "Arguments for `restart` request.",
 			"properties": {
 				"arguments": {
 					"oneOf": [
 						{ "$ref": "#/definitions/LaunchRequestArguments" },
 						{ "$ref": "#/definitions/AttachRequestArguments" }
 					],
-					"description": "The latest version of the 'launch' or 'attach' configuration."
+					"description": "The latest version of the `launch` or `attach` configuration."
 				}
 			}
 		},
 		"RestartResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'restart' request. This is just an acknowledgement, so no body field is required."
+				"description": "Response to `restart` request. This is just an acknowledgement, so no body field is required."
 			}]
 		},
 
 		"DisconnectRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The 'disconnect' request is sent from the client to the debug adapter in order to stop debugging.\nIt asks the debug adapter to disconnect from the debuggee and to terminate the debug adapter.\nIf the debuggee has been started with the 'launch' request, the 'disconnect' request terminates the debuggee.\nIf the 'attach' request was used to connect to the debuggee, 'disconnect' does not terminate the debuggee.\nThis behavior can be controlled with the 'terminateDebuggee' argument (if supported by the debug adapter).",
+				"description": "The `disconnect` request asks the debug adapter to disconnect from the debuggee (thus ending the debug session) and then to shut down itself (the debug adapter).\nIn addition, the debug adapter must terminate the debuggee if it was started with the `launch` request. If an `attach` request was used to connect to the debuggee, then the debug adapter must not terminate the debuggee.\nThis implicit behavior of when to terminate the debuggee can be overridden with the `terminateDebuggee` argument (which is only supported by a debug adapter if the corresponding capability `supportTerminateDebuggee` is true).",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1043,33 +1123,33 @@
 		},
 		"DisconnectArguments": {
 			"type": "object",
-			"description": "Arguments for 'disconnect' request.",
+			"description": "Arguments for `disconnect` request.",
 			"properties": {
 				"restart": {
 					"type": "boolean",
-					"description": "A value of true indicates that this 'disconnect' request is part of a restart sequence."
+					"description": "A value of true indicates that this `disconnect` request is part of a restart sequence."
 				},
 				"terminateDebuggee": {
 					"type": "boolean",
-					"description": "Indicates whether the debuggee should be terminated when the debugger is disconnected.\nIf unspecified, the debug adapter is free to do whatever it thinks is best.\nThe attribute is only honored by a debug adapter if the capability 'supportTerminateDebuggee' is true."
+					"description": "Indicates whether the debuggee should be terminated when the debugger is disconnected.\nIf unspecified, the debug adapter is free to do whatever it thinks is best.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportTerminateDebuggee` is true."
 				},
 				"suspendDebuggee": {
 					"type": "boolean",
-					"description": "Indicates whether the debuggee should stay suspended when the debugger is disconnected.\nIf unspecified, the debuggee should resume execution.\nThe attribute is only honored by a debug adapter if the capability 'supportSuspendDebuggee' is true."
+					"description": "Indicates whether the debuggee should stay suspended when the debugger is disconnected.\nIf unspecified, the debuggee should resume execution.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportSuspendDebuggee` is true."
 				}
 			}
 		},
 		"DisconnectResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'disconnect' request. This is just an acknowledgement, so no body field is required."
+				"description": "Response to `disconnect` request. This is just an acknowledgement, so no body field is required."
 			}]
 		},
 
 		"TerminateRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The 'terminate' request is sent from the client to the debug adapter in order to give the debuggee a chance for terminating itself.\nClients should only call this request if the capability 'supportsTerminateRequest' is true.",
+				"description": "The `terminate` request is sent from the client to the debug adapter in order to shut down the debuggee gracefully. Clients should only call this request if the capability `supportsTerminateRequest` is true.\nTypically a debug adapter implements `terminate` by sending a software signal which the debuggee intercepts in order to clean things up properly before terminating itself.\nPlease note that this request does not directly affect the state of the debug session: if the debuggee decides to veto the graceful shutdown for any reason by not terminating itself, then the debug session just continues.\nClients can surface the `terminate` request as an explicit command or they can integrate it into a two stage Stop command that first sends `terminate` to request a graceful shutdown, and if that fails uses `disconnect` for a forceful shutdown.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1084,25 +1164,25 @@
 		},
 		"TerminateArguments": {
 			"type": "object",
-			"description": "Arguments for 'terminate' request.",
+			"description": "Arguments for `terminate` request.",
 			"properties": {
 				"restart": {
 					"type": "boolean",
-					"description": "A value of true indicates that this 'terminate' request is part of a restart sequence."
+					"description": "A value of true indicates that this `terminate` request is part of a restart sequence."
 				}
 			}
 		},
 		"TerminateResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'terminate' request. This is just an acknowledgement, so no body field is required."
+				"description": "Response to `terminate` request. This is just an acknowledgement, so no body field is required."
 			}]
 		},
 
 		"BreakpointLocationsRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The 'breakpointLocations' request returns all possible locations for source breakpoints in a given range.\nClients should only call this request if the capability 'supportsBreakpointLocationsRequest' is true.",
+				"description": "The `breakpointLocations` request returns all possible locations for source breakpoints in a given range.\nClients should only call this request if the corresponding capability `supportsBreakpointLocationsRequest` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1118,11 +1198,11 @@
 		},
 		"BreakpointLocationsArguments": {
 			"type": "object",
-			"description": "Arguments for 'breakpointLocations' request.",
+			"description": "Arguments for `breakpointLocations` request.",
 			"properties": {
 				"source": {
 					"$ref": "#/definitions/Source",
-					"description": "The source location of the breakpoints; either 'source.path' or 'source.reference' must be specified."
+					"description": "The source location of the breakpoints; either `source.path` or `source.reference` must be specified."
 				},
 				"line": {
 					"type": "integer",
@@ -1130,15 +1210,15 @@
 				},
 				"column": {
 					"type": "integer",
-					"description": "Optional start column of range to search possible breakpoint locations in. If no start column is given, the first column in the start line is assumed."
+					"description": "Start position within `line` to search possible breakpoint locations in. It is measured in UTF-16 code units and the client capability `columnsStartAt1` determines whether it is 0- or 1-based. If no column is given, the first position in the start line is assumed."
 				},
 				"endLine": {
 					"type": "integer",
-					"description": "Optional end line of range to search possible breakpoint locations in. If no end line is given, then the end line is assumed to be the start line."
+					"description": "End line of range to search possible breakpoint locations in. If no end line is given, then the end line is assumed to be the start line."
 				},
 				"endColumn": {
 					"type": "integer",
-					"description": "Optional end column of range to search possible breakpoint locations in. If no end column is given, then it is assumed to be in the last column of the end line."
+					"description": "End position within `endLine` to search possible breakpoint locations in. It is measured in UTF-16 code units and the client capability `columnsStartAt1` determines whether it is 0- or 1-based. If no end column is given, the last position in the end line is assumed."
 				}
 			},
 			"required": [ "source", "line" ]
@@ -1146,7 +1226,7 @@
 		"BreakpointLocationsResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'breakpointLocations' request.\nContains possible locations for source breakpoints.",
+				"description": "Response to `breakpointLocations` request.\nContains possible locations for source breakpoints.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -1169,7 +1249,7 @@
 		"SetBreakpointsRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Sets multiple breakpoints for a single source and clears all previous breakpoints in that source.\nTo clear all breakpoint for a source, specify an empty array.\nWhen a breakpoint is hit, a 'stopped' event (with reason 'breakpoint') is generated.",
+				"description": "Sets multiple breakpoints for a single source and clears all previous breakpoints in that source.\nTo clear all breakpoint for a source, specify an empty array.\nWhen a breakpoint is hit, a `stopped` event (with reason `breakpoint`) is generated.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1184,11 +1264,11 @@
 		},
 		"SetBreakpointsArguments": {
 			"type": "object",
-			"description": "Arguments for 'setBreakpoints' request.",
+			"description": "Arguments for `setBreakpoints` request.",
 			"properties": {
 				"source": {
 					"$ref": "#/definitions/Source",
-					"description": "The source location of the breakpoints; either 'source.path' or 'source.reference' must be specified."
+					"description": "The source location of the breakpoints; either `source.path` or `source.sourceReference` must be specified."
 				},
 				"breakpoints": {
 					"type": "array",
@@ -1214,7 +1294,7 @@
 		"SetBreakpointsResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'setBreakpoints' request.\nReturned is information about each breakpoint created by this request.\nThis includes the actual code location and whether the breakpoint could be verified.\nThe breakpoints returned are in the same order as the elements of the 'breakpoints'\n(or the deprecated 'lines') array in the arguments.",
+				"description": "Response to `setBreakpoints` request.\nReturned is information about each breakpoint created by this request.\nThis includes the actual code location and whether the breakpoint could be verified.\nThe breakpoints returned are in the same order as the elements of the `breakpoints`\n(or the deprecated `lines`) array in the arguments.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -1224,7 +1304,7 @@
 								"items": {
 									"$ref": "#/definitions/Breakpoint"
 								},
-								"description": "Information about the breakpoints.\nThe array elements are in the same order as the elements of the 'breakpoints' (or the deprecated 'lines') array in the arguments."
+								"description": "Information about the breakpoints.\nThe array elements are in the same order as the elements of the `breakpoints` (or the deprecated `lines`) array in the arguments."
 							}
 						},
 						"required": [ "breakpoints" ]
@@ -1237,7 +1317,7 @@
 		"SetFunctionBreakpointsRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Replaces all existing function breakpoints with new function breakpoints.\nTo clear all function breakpoints, specify an empty array.\nWhen a function breakpoint is hit, a 'stopped' event (with reason 'function breakpoint') is generated.\nClients should only call this request if the capability 'supportsFunctionBreakpoints' is true.",
+				"description": "Replaces all existing function breakpoints with new function breakpoints.\nTo clear all function breakpoints, specify an empty array.\nWhen a function breakpoint is hit, a `stopped` event (with reason `function breakpoint`) is generated.\nClients should only call this request if the corresponding capability `supportsFunctionBreakpoints` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1252,7 +1332,7 @@
 		},
 		"SetFunctionBreakpointsArguments": {
 			"type": "object",
-			"description": "Arguments for 'setFunctionBreakpoints' request.",
+			"description": "Arguments for `setFunctionBreakpoints` request.",
 			"properties": {
 				"breakpoints": {
 					"type": "array",
@@ -1267,7 +1347,7 @@
 		"SetFunctionBreakpointsResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'setFunctionBreakpoints' request.\nReturned is information about each breakpoint created by this request.",
+				"description": "Response to `setFunctionBreakpoints` request.\nReturned is information about each breakpoint created by this request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -1277,7 +1357,7 @@
 								"items": {
 									"$ref": "#/definitions/Breakpoint"
 								},
-								"description": "Information about the breakpoints. The array elements correspond to the elements of the 'breakpoints' array."
+								"description": "Information about the breakpoints. The array elements correspond to the elements of the `breakpoints` array."
 							}
 						},
 						"required": [ "breakpoints" ]
@@ -1290,7 +1370,7 @@
 		"SetExceptionBreakpointsRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request configures the debuggers response to thrown exceptions.\nIf an exception is configured to break, a 'stopped' event is fired (with reason 'exception').\nClients should only call this request if the capability 'exceptionBreakpointFilters' returns one or more filters.",
+				"description": "The request configures the debugger's response to thrown exceptions.\nIf an exception is configured to break, a `stopped` event is fired (with reason `exception`).\nClients should only call this request if the corresponding capability `exceptionBreakpointFilters` returns one or more filters.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1305,28 +1385,28 @@
 		},
 		"SetExceptionBreakpointsArguments": {
 			"type": "object",
-			"description": "Arguments for 'setExceptionBreakpoints' request.",
+			"description": "Arguments for `setExceptionBreakpoints` request.",
 			"properties": {
 				"filters": {
 					"type": "array",
 					"items": {
 						"type": "string"
 					},
-					"description": "Set of exception filters specified by their ID. The set of all possible exception filters is defined by the 'exceptionBreakpointFilters' capability. The 'filter' and 'filterOptions' sets are additive."
+					"description": "Set of exception filters specified by their ID. The set of all possible exception filters is defined by the `exceptionBreakpointFilters` capability. The `filter` and `filterOptions` sets are additive."
 				},
 				"filterOptions": {
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/ExceptionFilterOptions"
 					},
-					"description": "Set of exception filters and their options. The set of all possible exception filters is defined by the 'exceptionBreakpointFilters' capability. This attribute is only honored by a debug adapter if the capability 'supportsExceptionFilterOptions' is true. The 'filter' and 'filterOptions' sets are additive."
+					"description": "Set of exception filters and their options. The set of all possible exception filters is defined by the `exceptionBreakpointFilters` capability. This attribute is only honored by a debug adapter if the corresponding capability `supportsExceptionFilterOptions` is true. The `filter` and `filterOptions` sets are additive."
 				},
 				"exceptionOptions": {
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/ExceptionOptions"
 					},
-					"description": "Configuration options for selected exceptions.\nThe attribute is only honored by a debug adapter if the capability 'supportsExceptionOptions' is true."
+					"description": "Configuration options for selected exceptions.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportsExceptionOptions` is true."
 				}
 			},
 			"required": [ "filters" ]
@@ -1334,7 +1414,7 @@
 		"SetExceptionBreakpointsResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'setExceptionBreakpoints' request.\nThe response contains an array of Breakpoint objects with information about each exception breakpoint or filter. The Breakpoint objects are in the same order as the elements of the 'filters', 'filterOptions', 'exceptionOptions' arrays given as arguments. If both 'filters' and 'filterOptions' are given, the returned array must start with 'filters' information first, followed by 'filterOptions' information.\nThe mandatory 'verified' property of a Breakpoint object signals whether the exception breakpoint or filter could be successfully created and whether the optional condition or hit count expressions are valid. In case of an error the 'message' property explains the problem. An optional 'id' property can be used to introduce a unique ID for the exception breakpoint or filter so that it can be updated subsequently by sending breakpoint events.\nFor backward compatibility both the 'breakpoints' array and the enclosing 'body' are optional. If these elements are missing a client will not be able to show problems for individual exception breakpoints or filters.",
+				"description": "Response to `setExceptionBreakpoints` request.\nThe response contains an array of `Breakpoint` objects with information about each exception breakpoint or filter. The `Breakpoint` objects are in the same order as the elements of the `filters`, `filterOptions`, `exceptionOptions` arrays given as arguments. If both `filters` and `filterOptions` are given, the returned array must start with `filters` information first, followed by `filterOptions` information.\nThe `verified` property of a `Breakpoint` object signals whether the exception breakpoint or filter could be successfully created and whether the condition or hit count expressions are valid. In case of an error the `message` property explains the problem. The `id` property can be used to introduce a unique ID for the exception breakpoint or filter so that it can be updated subsequently by sending breakpoint events.\nFor backward compatibility both the `breakpoints` array and the enclosing `body` are optional. If these elements are missing a client is not able to show problems for individual exception breakpoints or filters.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -1344,7 +1424,7 @@
 								"items": {
 									"$ref": "#/definitions/Breakpoint"
 								},
-								"description": "Information about the exception breakpoints or filters.\nThe breakpoints returned are in the same order as the elements of the 'filters', 'filterOptions', 'exceptionOptions' arrays in the arguments. If both 'filters' and 'filterOptions' are given, the returned array must start with 'filters' information first, followed by 'filterOptions' information."
+								"description": "Information about the exception breakpoints or filters.\nThe breakpoints returned are in the same order as the elements of the `filters`, `filterOptions`, `exceptionOptions` arrays in the arguments. If both `filters` and `filterOptions` are given, the returned array must start with `filters` information first, followed by `filterOptions` information."
 							}
 						}
 					}
@@ -1355,7 +1435,7 @@
 		"DataBreakpointInfoRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Obtains information on a possible data breakpoint that could be set on an expression or variable.\nClients should only call this request if the capability 'supportsDataBreakpoints' is true.",
+				"description": "Obtains information on a possible data breakpoint that could be set on an expression or variable.\nClients should only call this request if the corresponding capability `supportsDataBreakpoints` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1370,15 +1450,19 @@
 		},
 		"DataBreakpointInfoArguments": {
 			"type": "object",
-			"description": "Arguments for 'dataBreakpointInfo' request.",
+			"description": "Arguments for `dataBreakpointInfo` request.",
 			"properties": {
 				"variablesReference": {
 					"type": "integer",
-					"description": "Reference to the Variable container if the data breakpoint is requested for a child of the container."
+					"description": "Reference to the variable container if the data breakpoint is requested for a child of the container. The `variablesReference` must have been obtained in the current suspended state. See 'Lifetime of Object References' in the Overview section for details."
 				},
 				"name": {
 					"type": "string",
-					"description": "The name of the Variable's child to obtain data breakpoint information for.\nIf variablesReference isn’t provided, this can be an expression."
+					"description": "The name of the variable's child to obtain data breakpoint information for.\nIf `variablesReference` isn't specified, this can be an expression."
+				},
+				"frameId": {
+					"type": "integer",
+					"description": "When `name` is an expression, evaluate it in the scope of this stack frame. If not specified, the expression is evaluated in the global scope. When `variablesReference` is specified, this property has no effect."
 				}
 			},
 			"required": [ "name" ]
@@ -1386,14 +1470,14 @@
 		"DataBreakpointInfoResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'dataBreakpointInfo' request.",
+				"description": "Response to `dataBreakpointInfo` request.",
 				"properties": {
 					"body": {
 						"type": "object",
 						"properties": {
 							"dataId": {
 								"type": [ "string", "null" ],
-								"description": "An identifier for the data on which a data breakpoint can be registered with the setDataBreakpoints request or null if no data breakpoint is available."
+								"description": "An identifier for the data on which a data breakpoint can be registered with the `setDataBreakpoints` request or null if no data breakpoint is available."
 							},
 							"description": {
 								"type": "string",
@@ -1404,11 +1488,11 @@
 								"items": {
 									"$ref": "#/definitions/DataBreakpointAccessType"
 								},
-								"description": "Optional attribute listing the available access types for a potential data breakpoint. A UI frontend could surface this information."
+								"description": "Attribute lists the available access types for a potential data breakpoint. A UI client could surface this information."
 							},
 							"canPersist": {
 								"type": "boolean",
-								"description": "Optional attribute indicating that a potential data breakpoint could be persisted across sessions."
+								"description": "Attribute indicates that a potential data breakpoint could be persisted across sessions."
 							}
 						},
 						"required": [ "dataId", "description" ]
@@ -1421,7 +1505,7 @@
 		"SetDataBreakpointsRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Replaces all existing data breakpoints with new data breakpoints.\nTo clear all data breakpoints, specify an empty array.\nWhen a data breakpoint is hit, a 'stopped' event (with reason 'data breakpoint') is generated.\nClients should only call this request if the capability 'supportsDataBreakpoints' is true.",
+				"description": "Replaces all existing data breakpoints with new data breakpoints.\nTo clear all data breakpoints, specify an empty array.\nWhen a data breakpoint is hit, a `stopped` event (with reason `data breakpoint`) is generated.\nClients should only call this request if the corresponding capability `supportsDataBreakpoints` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1436,7 +1520,7 @@
 		},
 		"SetDataBreakpointsArguments": {
 			"type": "object",
-			"description": "Arguments for 'setDataBreakpoints' request.",
+			"description": "Arguments for `setDataBreakpoints` request.",
 			"properties": {
 				"breakpoints": {
 					"type": "array",
@@ -1451,7 +1535,7 @@
 		"SetDataBreakpointsResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'setDataBreakpoints' request.\nReturned is information about each breakpoint created by this request.",
+				"description": "Response to `setDataBreakpoints` request.\nReturned is information about each breakpoint created by this request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -1461,7 +1545,7 @@
 								"items": {
 									"$ref": "#/definitions/Breakpoint"
 								},
-								"description": "Information about the data breakpoints. The array elements correspond to the elements of the input argument 'breakpoints' array."
+								"description": "Information about the data breakpoints. The array elements correspond to the elements of the input argument `breakpoints` array."
 							}
 						},
 						"required": [ "breakpoints" ]
@@ -1476,7 +1560,7 @@
 				{ "$ref": "#/definitions/Request" },
 				{
 					"type": "object",
-					"description": "Replaces all existing instruction breakpoints. Typically, instruction breakpoints would be set from a diassembly window. \nTo clear all instruction breakpoints, specify an empty array.\nWhen an instruction breakpoint is hit, a 'stopped' event (with reason 'instruction breakpoint') is generated.\nClients should only call this request if the capability 'supportsInstructionBreakpoints' is true.",
+					"description": "Replaces all existing instruction breakpoints. Typically, instruction breakpoints would be set from a disassembly window. \nTo clear all instruction breakpoints, specify an empty array.\nWhen an instruction breakpoint is hit, a `stopped` event (with reason `instruction breakpoint`) is generated.\nClients should only call this request if the corresponding capability `supportsInstructionBreakpoints` is true.",
 					"properties": {
 						"command": {
 						"type": "string",
@@ -1491,7 +1575,7 @@
 		},
 		"SetInstructionBreakpointsArguments": {
 			"type": "object",
-			"description": "Arguments for 'setInstructionBreakpoints' request",
+			"description": "Arguments for `setInstructionBreakpoints` request",
 			"properties": {
 				"breakpoints": {
 					"type": "array",
@@ -1508,7 +1592,7 @@
 				{ "$ref": "#/definitions/Response" },
 				{
 					"type": "object",
-					"description": "Response to 'setInstructionBreakpoints' request",
+					"description": "Response to `setInstructionBreakpoints` request",
 					"properties": {
 						"body": {
 							"type": "object",
@@ -1518,7 +1602,7 @@
 									"items": {
 										"$ref": "#/definitions/Breakpoint"
 									},
-								"description": "Information about the breakpoints. The array elements correspond to the elements of the 'breakpoints' array."
+								"description": "Information about the breakpoints. The array elements correspond to the elements of the `breakpoints` array."
 							}
 						},
 						"required": [ "breakpoints" ]
@@ -1531,7 +1615,7 @@
 		"ContinueRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request starts the debuggee to run again.",
+				"description": "The request resumes execution of all threads. If the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true resumes only the specified thread. If not all threads were resumed, the `allThreadsContinued` attribute of the response should be set to false.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1546,11 +1630,15 @@
 		},
 		"ContinueArguments": {
 			"type": "object",
-			"description": "Arguments for 'continue' request.",
+			"description": "Arguments for `continue` request.",
 			"properties": {
 				"threadId": {
 					"type": "integer",
-					"description": "Continue execution for the specified thread (if possible).\nIf the backend cannot continue on a single thread but will continue on all threads, it should set the 'allThreadsContinued' attribute in the response to true."
+					"description": "Specifies the active thread. If the debug adapter supports single thread execution (see `supportsSingleThreadExecutionRequests`) and the argument `singleThread` is true, only the thread with this ID is resumed."
+				},
+				"singleThread": {
+					"type": "boolean",
+					"description": "If this flag is true, execution is resumed only for the thread with given `threadId`."
 				}
 			},
 			"required": [ "threadId" ]
@@ -1558,14 +1646,14 @@
 		"ContinueResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'continue' request.",
+				"description": "Response to `continue` request.",
 				"properties": {
 					"body": {
 						"type": "object",
 						"properties": {
 							"allThreadsContinued": {
 								"type": "boolean",
-								"description": "If true, the 'continue' request has ignored the specified thread and continued all threads instead.\nIf this attribute is missing a value of 'true' is assumed for backward compatibility."
+								"description": "The value true (or a missing property) signals to the client that all threads have been resumed. The value false indicates that not all threads were resumed."
 							}
 						}
 					}
@@ -1577,7 +1665,7 @@
 		"NextRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request starts the debuggee to run again for one step.\nThe debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed.",
+				"description": "The request executes one step (in the given granularity) for the specified thread and allows all other threads to run freely by resuming them.\nIf the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true prevents other suspended threads from resuming.\nThe debug adapter first sends the response and then a `stopped` event (with reason `step`) after the step has completed.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1592,15 +1680,19 @@
 		},
 		"NextArguments": {
 			"type": "object",
-			"description": "Arguments for 'next' request.",
+			"description": "Arguments for `next` request.",
 			"properties": {
 				"threadId": {
 					"type": "integer",
-					"description": "Execute 'next' for this thread."
+					"description": "Specifies the thread for which to resume execution for one step (of the given granularity)."
+				},
+				"singleThread": {
+					"type": "boolean",
+					"description": "If this flag is true, all other suspended threads are not resumed."
 				},
 				"granularity": {
 					"$ref": "#/definitions/SteppingGranularity",
-					"description": "Optional granularity to step. If no granularity is specified, a granularity of 'statement' is assumed."
+					"description": "Stepping granularity. If no granularity is specified, a granularity of `statement` is assumed."
 				}
 			},
 			"required": [ "threadId" ]
@@ -1608,14 +1700,14 @@
 		"NextResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'next' request. This is just an acknowledgement, so no body field is required."
+				"description": "Response to `next` request. This is just an acknowledgement, so no body field is required."
 			}]
 		},
 
 		"StepInRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request starts the debuggee to step into a function/method if possible.\nIf it cannot step into a target, 'stepIn' behaves like 'next'.\nThe debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed.\nIf there are multiple function/method calls (or other targets) on the source line,\nthe optional argument 'targetId' can be used to control into which target the 'stepIn' should occur.\nThe list of possible targets for a given source line can be retrieved via the 'stepInTargets' request.",
+				"description": "The request resumes the given thread to step into a function/method and allows all other threads to run freely by resuming them.\nIf the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true prevents other suspended threads from resuming.\nIf the request cannot step into a target, `stepIn` behaves like the `next` request.\nThe debug adapter first sends the response and then a `stopped` event (with reason `step`) after the step has completed.\nIf there are multiple function/method calls (or other targets) on the source line,\nthe argument `targetId` can be used to control into which target the `stepIn` should occur.\nThe list of possible targets for a given source line can be retrieved via the `stepInTargets` request.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1630,19 +1722,23 @@
 		},
 		"StepInArguments": {
 			"type": "object",
-			"description": "Arguments for 'stepIn' request.",
+			"description": "Arguments for `stepIn` request.",
 			"properties": {
 				"threadId": {
 					"type": "integer",
-					"description": "Execute 'stepIn' for this thread."
+					"description": "Specifies the thread for which to resume execution for one step-into (of the given granularity)."
+				},
+				"singleThread": {
+					"type": "boolean",
+					"description": "If this flag is true, all other suspended threads are not resumed."
 				},
 				"targetId": {
 					"type": "integer",
-					"description": "Optional id of the target to step into."
+					"description": "Id of the target to step into."
 				},
 				"granularity": {
 					"$ref": "#/definitions/SteppingGranularity",
-					"description": "Optional granularity to step. If no granularity is specified, a granularity of 'statement' is assumed."
+					"description": "Stepping granularity. If no granularity is specified, a granularity of `statement` is assumed."
 				}
 			},
 			"required": [ "threadId" ]
@@ -1650,14 +1746,14 @@
 		"StepInResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'stepIn' request. This is just an acknowledgement, so no body field is required."
+				"description": "Response to `stepIn` request. This is just an acknowledgement, so no body field is required."
 			}]
 		},
 
 		"StepOutRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request starts the debuggee to run again for one step.\nThe debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed.",
+				"description": "The request resumes the given thread to step out (return) from a function/method and allows all other threads to run freely by resuming them.\nIf the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true prevents other suspended threads from resuming.\nThe debug adapter first sends the response and then a `stopped` event (with reason `step`) after the step has completed.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1672,15 +1768,19 @@
 		},
 		"StepOutArguments": {
 			"type": "object",
-			"description": "Arguments for 'stepOut' request.",
+			"description": "Arguments for `stepOut` request.",
 			"properties": {
 				"threadId": {
 					"type": "integer",
-					"description": "Execute 'stepOut' for this thread."
+					"description": "Specifies the thread for which to resume execution for one step-out (of the given granularity)."
+				},
+				"singleThread": {
+					"type": "boolean",
+					"description": "If this flag is true, all other suspended threads are not resumed."
 				},
 				"granularity": {
 					"$ref": "#/definitions/SteppingGranularity",
-					"description": "Optional granularity to step. If no granularity is specified, a granularity of 'statement' is assumed."
+					"description": "Stepping granularity. If no granularity is specified, a granularity of `statement` is assumed."
 				}
 			},
 			"required": [ "threadId" ]
@@ -1688,14 +1788,14 @@
 		"StepOutResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'stepOut' request. This is just an acknowledgement, so no body field is required."
+				"description": "Response to `stepOut` request. This is just an acknowledgement, so no body field is required."
 			}]
 		},
 
 		"StepBackRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request starts the debuggee to run one step backwards.\nThe debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed.\nClients should only call this request if the capability 'supportsStepBack' is true.",
+				"description": "The request executes one backward step (in the given granularity) for the specified thread and allows all other threads to run backward freely by resuming them.\nIf the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true prevents other suspended threads from resuming.\nThe debug adapter first sends the response and then a `stopped` event (with reason `step`) after the step has completed.\nClients should only call this request if the corresponding capability `supportsStepBack` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1710,15 +1810,19 @@
 		},
 		"StepBackArguments": {
 			"type": "object",
-			"description": "Arguments for 'stepBack' request.",
+			"description": "Arguments for `stepBack` request.",
 			"properties": {
 				"threadId": {
 					"type": "integer",
-					"description": "Execute 'stepBack' for this thread."
+					"description": "Specifies the thread for which to resume execution for one step backwards (of the given granularity)."
+				},
+				"singleThread": {
+					"type": "boolean",
+					"description": "If this flag is true, all other suspended threads are not resumed."
 				},
 				"granularity": {
 					"$ref": "#/definitions/SteppingGranularity",
-					"description": "Optional granularity to step. If no granularity is specified, a granularity of 'statement' is assumed."
+					"description": "Stepping granularity to step. If no granularity is specified, a granularity of `statement` is assumed."
 				}
 			},
 			"required": [ "threadId" ]
@@ -1726,14 +1830,14 @@
 		"StepBackResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'stepBack' request. This is just an acknowledgement, so no body field is required."
+				"description": "Response to `stepBack` request. This is just an acknowledgement, so no body field is required."
 			}]
 		},
 
 		"ReverseContinueRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request starts the debuggee to run backward.\nClients should only call this request if the capability 'supportsStepBack' is true.",
+				"description": "The request resumes backward execution of all threads. If the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true resumes only the specified thread. If not all threads were resumed, the `allThreadsContinued` attribute of the response should be set to false.\nClients should only call this request if the corresponding capability `supportsStepBack` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1748,26 +1852,31 @@
 		},
 		"ReverseContinueArguments": {
 			"type": "object",
-			"description": "Arguments for 'reverseContinue' request.",
+			"description": "Arguments for `reverseContinue` request.",
 			"properties": {
 				"threadId": {
 					"type": "integer",
-					"description": "Execute 'reverseContinue' for this thread."
+					"description": "Specifies the active thread. If the debug adapter supports single thread execution (see `supportsSingleThreadExecutionRequests`) and the `singleThread` argument is true, only the thread with this ID is resumed."
+				},
+				"singleThread": {
+					"type": "boolean",
+					"description": "If this flag is true, backward execution is resumed only for the thread with given `threadId`."
 				}
+
 			},
 			"required": [ "threadId" ]
 		},
 		"ReverseContinueResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'reverseContinue' request. This is just an acknowledgement, so no body field is required."
+				"description": "Response to `reverseContinue` request. This is just an acknowledgement, so no body field is required."
 			}]
 		},
 
 		"RestartFrameRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request restarts execution of the specified stackframe.\nThe debug adapter first sends the response and then a 'stopped' event (with reason 'restart') after the restart has completed.\nClients should only call this request if the capability 'supportsRestartFrame' is true.",
+				"description": "The request restarts execution of the specified stack frame.\nThe debug adapter first sends the response and then a `stopped` event (with reason `restart`) after the restart has completed.\nClients should only call this request if the corresponding capability `supportsRestartFrame` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1782,11 +1891,11 @@
 		},
 		"RestartFrameArguments": {
 			"type": "object",
-			"description": "Arguments for 'restartFrame' request.",
+			"description": "Arguments for `restartFrame` request.",
 			"properties": {
 				"frameId": {
 					"type": "integer",
-					"description": "Restart this stackframe."
+					"description": "Restart the stack frame identified by `frameId`. The `frameId` must have been obtained in the current suspended state. See 'Lifetime of Object References' in the Overview section for details."
 				}
 			},
 			"required": [ "frameId" ]
@@ -1794,14 +1903,14 @@
 		"RestartFrameResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'restartFrame' request. This is just an acknowledgement, so no body field is required."
+				"description": "Response to `restartFrame` request. This is just an acknowledgement, so no body field is required."
 			}]
 		},
 
 		"GotoRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request sets the location where the debuggee will continue to run.\nThis makes it possible to skip the execution of code or to executed code again.\nThe code between the current location and the goto target is not executed but skipped.\nThe debug adapter first sends the response and then a 'stopped' event with reason 'goto'.\nClients should only call this request if the capability 'supportsGotoTargetsRequest' is true (because only then goto targets exist that can be passed as arguments).",
+				"description": "The request sets the location where the debuggee will continue to run.\nThis makes it possible to skip the execution of code or to execute code again.\nThe code between the current location and the goto target is not executed but skipped.\nThe debug adapter first sends the response and then a `stopped` event with reason `goto`.\nClients should only call this request if the corresponding capability `supportsGotoTargetsRequest` is true (because only then goto targets exist that can be passed as arguments).",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1816,7 +1925,7 @@
 		},
 		"GotoArguments": {
 			"type": "object",
-			"description": "Arguments for 'goto' request.",
+			"description": "Arguments for `goto` request.",
 			"properties": {
 				"threadId": {
 					"type": "integer",
@@ -1832,14 +1941,14 @@
 		"GotoResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'goto' request. This is just an acknowledgement, so no body field is required."
+				"description": "Response to `goto` request. This is just an acknowledgement, so no body field is required."
 			}]
 		},
 
 		"PauseRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request suspends the debuggee.\nThe debug adapter first sends the response and then a 'stopped' event (with reason 'pause') after the thread has been paused successfully.",
+				"description": "The request suspends the debuggee.\nThe debug adapter first sends the response and then a `stopped` event (with reason `pause`) after the thread has been paused successfully.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1854,7 +1963,7 @@
 		},
 		"PauseArguments": {
 			"type": "object",
-			"description": "Arguments for 'pause' request.",
+			"description": "Arguments for `pause` request.",
 			"properties": {
 				"threadId": {
 					"type": "integer",
@@ -1866,14 +1975,14 @@
 		"PauseResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'pause' request. This is just an acknowledgement, so no body field is required."
+				"description": "Response to `pause` request. This is just an acknowledgement, so no body field is required."
 			}]
 		},
 
 		"StackTraceRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request returns a stacktrace from the current execution state of a given thread.\nA client can request all stack frames by omitting the startFrame and levels arguments. For performance conscious clients and if the debug adapter's 'supportsDelayedStackTraceLoading' capability is true, stack frames can be retrieved in a piecemeal way with the startFrame and levels arguments. The response of the stackTrace request may contain a totalFrames property that hints at the total number of frames in the stack. If a client needs this total number upfront, it can issue a request for a single (first) frame and depending on the value of totalFrames decide how to proceed. In any case a client should be prepared to receive less frames than requested, which is an indication that the end of the stack has been reached.",
+				"description": "The request returns a stacktrace from the current execution state of a given thread.\nA client can request all stack frames by omitting the startFrame and levels arguments. For performance-conscious clients and if the corresponding capability `supportsDelayedStackTraceLoading` is true, stack frames can be retrieved in a piecemeal way with the `startFrame` and `levels` arguments. The response of the `stackTrace` request may contain a `totalFrames` property that hints at the total number of frames in the stack. If a client needs this total number upfront, it can issue a request for a single (first) frame and depending on the value of `totalFrames` decide how to proceed. In any case a client should be prepared to receive fewer frames than requested, which is an indication that the end of the stack has been reached.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1888,7 +1997,7 @@
 		},
 		"StackTraceArguments": {
 			"type": "object",
-			"description": "Arguments for 'stackTrace' request.",
+			"description": "Arguments for `stackTrace` request.",
 			"properties": {
 				"threadId": {
 					"type": "integer",
@@ -1904,7 +2013,7 @@
 				},
 				"format": {
 					"$ref": "#/definitions/StackFrameFormat",
-					"description": "Specifies details on how to format the stack frames.\nThe attribute is only honored by a debug adapter if the capability 'supportsValueFormattingOptions' is true."
+					"description": "Specifies details on how to format the stack frames.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportsValueFormattingOptions` is true."
 				}
 			},
 			"required": [ "threadId" ]
@@ -1912,7 +2021,7 @@
 		"StackTraceResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'stackTrace' request.",
+				"description": "Response to `stackTrace` request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -1922,11 +2031,11 @@
 								"items": {
 									"$ref": "#/definitions/StackFrame"
 								},
-								"description": "The frames of the stackframe. If the array has length zero, there are no stackframes available.\nThis means that there is no location information available."
+								"description": "The frames of the stack frame. If the array has length zero, there are no stack frames available.\nThis means that there is no location information available."
 							},
 							"totalFrames": {
 								"type": "integer",
-								"description": "The total number of frames available in the stack. If omitted or if totalFrames is larger than the available frames, a client is expected to request frames until a request returns less frames than requested (which indicates the end of the stack). Returning monotonically increasing totalFrames values for subsequent requests can be used to enforce paging in the client."
+								"description": "The total number of frames available in the stack. If omitted or if `totalFrames` is larger than the available frames, a client is expected to request frames until a request returns less frames than requested (which indicates the end of the stack). Returning monotonically increasing `totalFrames` values for subsequent requests can be used to enforce paging in the client."
 							}
 						},
 						"required": [ "stackFrames" ]
@@ -1939,7 +2048,7 @@
 		"ScopesRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request returns the variable scopes for a given stackframe ID.",
+				"description": "The request returns the variable scopes for a given stack frame ID.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -1954,11 +2063,11 @@
 		},
 		"ScopesArguments": {
 			"type": "object",
-			"description": "Arguments for 'scopes' request.",
+			"description": "Arguments for `scopes` request.",
 			"properties": {
 				"frameId": {
 					"type": "integer",
-					"description": "Retrieve the scopes for this stackframe."
+					"description": "Retrieve the scopes for the stack frame identified by `frameId`. The `frameId` must have been obtained in the current suspended state. See 'Lifetime of Object References' in the Overview section for details."
 				}
 			},
 			"required": [ "frameId" ]
@@ -1966,7 +2075,7 @@
 		"ScopesResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'scopes' request.",
+				"description": "Response to `scopes` request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -1976,7 +2085,7 @@
 								"items": {
 									"$ref": "#/definitions/Scope"
 								},
-								"description": "The scopes of the stackframe. If the array has length zero, there are no scopes available."
+								"description": "The scopes of the stack frame. If the array has length zero, there are no scopes available."
 							}
 						},
 						"required": [ "scopes" ]
@@ -1989,7 +2098,7 @@
 		"VariablesRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Retrieves all child variables for the given variable reference.\nAn optional filter can be used to limit the fetched children to either named or indexed children.",
+				"description": "Retrieves all child variables for the given variable reference.\nA filter can be used to limit the fetched children to either named or indexed children.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2004,16 +2113,16 @@
 		},
 		"VariablesArguments": {
 			"type": "object",
-			"description": "Arguments for 'variables' request.",
+			"description": "Arguments for `variables` request.",
 			"properties": {
 				"variablesReference": {
 					"type": "integer",
-					"description": "The Variable reference."
+					"description": "The variable for which to retrieve its children. The `variablesReference` must have been obtained in the current suspended state. See 'Lifetime of Object References' in the Overview section for details."
 				},
 				"filter": {
 					"type": "string",
 					"enum": [ "indexed", "named" ],
-					"description": "Optional filter to limit the child variables to either named or indexed. If omitted, both types are fetched."
+					"description": "Filter to limit the child variables to either named or indexed. If omitted, both types are fetched."
 				},
 				"start": {
 					"type": "integer",
@@ -2025,7 +2134,7 @@
 				},
 				"format": {
 					"$ref": "#/definitions/ValueFormat",
-					"description": "Specifies details on how to format the Variable values.\nThe attribute is only honored by a debug adapter if the capability 'supportsValueFormattingOptions' is true."
+					"description": "Specifies details on how to format the Variable values.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportsValueFormattingOptions` is true."
 				}
 			},
 			"required": [ "variablesReference" ]
@@ -2033,7 +2142,7 @@
 		"VariablesResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'variables' request.",
+				"description": "Response to `variables` request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -2056,7 +2165,7 @@
 		"SetVariableRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Set the variable with the given name in the variable container to a new value. Clients should only call this request if the capability 'supportsSetVariable' is true.\nIf a debug adapter implements both setVariable and setExpression, a client will only use setExpression if the variable has an evaluateName property.",
+				"description": "Set the variable with the given name in the variable container to a new value. Clients should only call this request if the corresponding capability `supportsSetVariable` is true.\nIf a debug adapter implements both `setVariable` and `setExpression`, a client will only use `setExpression` if the variable has an `evaluateName` property.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2071,11 +2180,11 @@
 		},
 		"SetVariableArguments": {
 			"type": "object",
-			"description": "Arguments for 'setVariable' request.",
+			"description": "Arguments for `setVariable` request.",
 			"properties": {
 				"variablesReference": {
 					"type": "integer",
-					"description": "The reference of the variable container."
+					"description": "The reference of the variable container. The `variablesReference` must have been obtained in the current suspended state. See 'Lifetime of Object References' in the Overview section for details."
 				},
 				"name": {
 					"type": "string",
@@ -2095,7 +2204,7 @@
 		"SetVariableResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'setVariable' request.",
+				"description": "Response to `setVariable` request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -2110,15 +2219,15 @@
 							},
 							"variablesReference": {
 								"type": "integer",
-								"description": "If variablesReference is > 0, the new value is structured and its children can be retrieved by passing variablesReference to the VariablesRequest.\nThe value should be less than or equal to 2147483647 (2^31-1)."
+								"description": "If `variablesReference` is > 0, the new value is structured and its children can be retrieved by passing `variablesReference` to the `variables` request as long as execution remains suspended. See 'Lifetime of Object References' in the Overview section for details."
 							},
 							"namedVariables": {
 								"type": "integer",
-								"description": "The number of named child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31-1)."
+								"description": "The number of named child variables.\nThe client can use this information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31-1)."
 							},
 							"indexedVariables": {
 								"type": "integer",
-								"description": "The number of indexed child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31-1)."
+								"description": "The number of indexed child variables.\nThe client can use this information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31-1)."
 							}
 						},
 						"required": [ "value" ]
@@ -2146,15 +2255,15 @@
 		},
 		"SourceArguments": {
 			"type": "object",
-			"description": "Arguments for 'source' request.",
+			"description": "Arguments for `source` request.",
 			"properties": {
 				"source": {
 					"$ref": "#/definitions/Source",
-					"description": "Specifies the source content to load. Either source.path or source.sourceReference must be specified."
+					"description": "Specifies the source content to load. Either `source.path` or `source.sourceReference` must be specified."
 				},
 				"sourceReference": {
 					"type": "integer",
-					"description": "The reference to the source. This is the same as source.sourceReference.\nThis is provided for backward compatibility since old backends do not understand the 'source' attribute."
+					"description": "The reference to the source. This is the same as `source.sourceReference`.\nThis is provided for backward compatibility since old clients do not understand the `source` attribute."
 				}
 			},
 			"required": [ "sourceReference" ]
@@ -2162,7 +2271,7 @@
 		"SourceResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'source' request.",
+				"description": "Response to `source` request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -2173,7 +2282,7 @@
 							},
 							"mimeType": {
 								"type": "string",
-								"description": "Optional content type (mime type) of the source."
+								"description": "Content type (MIME type) of the source."
 							}
 						},
 						"required": [ "content" ]
@@ -2199,7 +2308,7 @@
 		"ThreadsResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'threads' request.",
+				"description": "Response to `threads` request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -2222,7 +2331,7 @@
 		"TerminateThreadsRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "The request terminates the threads with the given ids.\nClients should only call this request if the capability 'supportsTerminateThreadsRequest' is true.",
+				"description": "The request terminates the threads with the given ids.\nClients should only call this request if the corresponding capability `supportsTerminateThreadsRequest` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2237,7 +2346,7 @@
 		},
 		"TerminateThreadsArguments": {
 			"type": "object",
-			"description": "Arguments for 'terminateThreads' request.",
+			"description": "Arguments for `terminateThreads` request.",
 			"properties": {
 				"threadIds": {
 					"type": "array",
@@ -2251,14 +2360,14 @@
 		"TerminateThreadsResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'terminateThreads' request. This is just an acknowledgement, so no body field is required."
+				"description": "Response to `terminateThreads` request. This is just an acknowledgement, no body field is required."
 			}]
 		},
 
 		"ModulesRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Modules can be retrieved from the debug adapter with this request which can either return all modules or a range of modules to support paging.\nClients should only call this request if the capability 'supportsModulesRequest' is true.",
+				"description": "Modules can be retrieved from the debug adapter with this request which can either return all modules or a range of modules to support paging.\nClients should only call this request if the corresponding capability `supportsModulesRequest` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2273,7 +2382,7 @@
 		},
 		"ModulesArguments": {
 			"type": "object",
-			"description": "Arguments for 'modules' request.",
+			"description": "Arguments for `modules` request.",
 			"properties": {
 				"startModule": {
 					"type": "integer",
@@ -2281,14 +2390,14 @@
 				},
 				"moduleCount": {
 					"type": "integer",
-					"description": "The number of modules to return. If moduleCount is not specified or 0, all modules are returned."
+					"description": "The number of modules to return. If `moduleCount` is not specified or 0, all modules are returned."
 				}
 			}
 		},
 		"ModulesResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'modules' request.",
+				"description": "Response to `modules` request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -2315,7 +2424,7 @@
 		"LoadedSourcesRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Retrieves the set of all sources currently loaded by the debugged process.\nClients should only call this request if the capability 'supportsLoadedSourcesRequest' is true.",
+				"description": "Retrieves the set of all sources currently loaded by the debugged process.\nClients should only call this request if the corresponding capability `supportsLoadedSourcesRequest` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2330,12 +2439,12 @@
 		},
 		"LoadedSourcesArguments": {
 			"type": "object",
-			"description": "Arguments for 'loadedSources' request."
+			"description": "Arguments for `loadedSources` request."
 		},
 		"LoadedSourcesResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'loadedSources' request.",
+				"description": "Response to `loadedSources` request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -2358,7 +2467,7 @@
 		"EvaluateRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Evaluates the given expression in the context of the top most stack frame.\nThe expression has access to any variables and arguments that are in scope.",
+				"description": "Evaluates the given expression in the context of the topmost stack frame.\nThe expression has access to any variables and arguments that are in scope.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2373,7 +2482,7 @@
 		},
 		"EvaluateArguments": {
 			"type": "object",
-			"description": "Arguments for 'evaluate' request.",
+			"description": "Arguments for `evaluate` request.",
 			"properties": {
 				"expression": {
 					"type": "string",
@@ -2385,18 +2494,19 @@
 				},
 				"context": {
 					"type": "string",
-					"_enum": [ "watch", "repl", "hover", "clipboard" ],
+					"_enum": [ "watch", "repl", "hover", "clipboard", "variables" ],
 					"enumDescriptions": [
-						"evaluate is run in a watch.",
-						"evaluate is run from REPL console.",
-						"evaluate is run from a data hover.",
-						"evaluate is run to generate the value that will be stored in the clipboard.\nThe attribute is only honored by a debug adapter if the capability 'supportsClipboardContext' is true."
+						"evaluate is called from a watch view context.",
+						"evaluate is called from a REPL context.",
+						"evaluate is called to generate the debug hover contents.\nThis value should only be used if the corresponding capability `supportsEvaluateForHovers` is true.",
+						"evaluate is called to generate clipboard contents.\nThis value should only be used if the corresponding capability `supportsClipboardContext` is true.",
+						"evaluate is called from a variables view context."
 					],
-					"description": "The context in which the evaluate request is run."
+					"description": "The context in which the evaluate request is used."
 				},
 				"format": {
 					"$ref": "#/definitions/ValueFormat",
-					"description": "Specifies details on how to format the Evaluate result.\nThe attribute is only honored by a debug adapter if the capability 'supportsValueFormattingOptions' is true."
+					"description": "Specifies details on how to format the result.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportsValueFormattingOptions` is true."
 				}
 			},
 			"required": [ "expression" ]
@@ -2404,7 +2514,7 @@
 		"EvaluateResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'evaluate' request.",
+				"description": "Response to `evaluate` request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -2415,27 +2525,27 @@
 							},
 							"type": {
 								"type": "string",
-								"description": "The optional type of the evaluate result.\nThis attribute should only be returned by a debug adapter if the client has passed the value true for the 'supportsVariableType' capability of the 'initialize' request."
+								"description": "The type of the evaluate result.\nThis attribute should only be returned by a debug adapter if the corresponding capability `supportsVariableType` is true."
 							},
 							"presentationHint": {
 								"$ref": "#/definitions/VariablePresentationHint",
-								"description": "Properties of a evaluate result that can be used to determine how to render the result in the UI."
+								"description": "Properties of an evaluate result that can be used to determine how to render the result in the UI."
 							},
 							"variablesReference": {
 								"type": "integer",
-								"description": "If variablesReference is > 0, the evaluate result is structured and its children can be retrieved by passing variablesReference to the VariablesRequest.\nThe value should be less than or equal to 2147483647 (2^31-1)."
+								"description": "If `variablesReference` is > 0, the evaluate result is structured and its children can be retrieved by passing `variablesReference` to the `variables` request as long as execution remains suspended. See 'Lifetime of Object References' in the Overview section for details."
 							},
 							"namedVariables": {
 								"type": "integer",
-								"description": "The number of named child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31-1)."
+								"description": "The number of named child variables.\nThe client can use this information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31-1)."
 							},
 							"indexedVariables": {
 								"type": "integer",
-								"description": "The number of indexed child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31-1)."
+								"description": "The number of indexed child variables.\nThe client can use this information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31-1)."
 							},
 							"memoryReference": {
 								"type": "string",
-								"description": "Optional memory reference to a location appropriate for this result.\nFor pointer type eval results, this is generally a reference to the memory address contained in the pointer.\nThis attribute should be returned by a debug adapter if the client has passed the value true for the 'supportsMemoryReferences' capability of the 'initialize' request."
+								"description": "A memory reference to a location appropriate for this result.\nFor pointer type eval results, this is generally a reference to the memory address contained in the pointer.\nThis attribute should be returned by a debug adapter if corresponding capability `supportsMemoryReferences` is true."
 							}
 						},
 						"required": [ "result", "variablesReference" ]
@@ -2448,7 +2558,7 @@
 		"SetExpressionRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Evaluates the given 'value' expression and assigns it to the 'expression' which must be a modifiable l-value.\nThe expressions have access to any variables and arguments that are in scope of the specified frame.\nClients should only call this request if the capability 'supportsSetExpression' is true.\nIf a debug adapter implements both setExpression and setVariable, a client will only use setExpression if the variable has an evaluateName property.",
+				"description": "Evaluates the given `value` expression and assigns it to the `expression` which must be a modifiable l-value.\nThe expressions have access to any variables and arguments that are in scope of the specified frame.\nClients should only call this request if the corresponding capability `supportsSetExpression` is true.\nIf a debug adapter implements both `setExpression` and `setVariable`, a client uses `setExpression` if the variable has an `evaluateName` property.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2463,7 +2573,7 @@
 		},
 		"SetExpressionArguments": {
 			"type": "object",
-			"description": "Arguments for 'setExpression' request.",
+			"description": "Arguments for `setExpression` request.",
 			"properties": {
 				"expression": {
 					"type": "string",
@@ -2487,7 +2597,7 @@
 		"SetExpressionResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'setExpression' request.",
+				"description": "Response to `setExpression` request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -2498,7 +2608,7 @@
 							},
 							"type": {
 								"type": "string",
-								"description": "The optional type of the value.\nThis attribute should only be returned by a debug adapter if the client has passed the value true for the 'supportsVariableType' capability of the 'initialize' request."
+								"description": "The type of the value.\nThis attribute should only be returned by a debug adapter if the corresponding capability `supportsVariableType` is true."
 							},
 							"presentationHint": {
 								"$ref": "#/definitions/VariablePresentationHint",
@@ -2506,15 +2616,15 @@
 							},
 							"variablesReference": {
 								"type": "integer",
-								"description": "If variablesReference is > 0, the value is structured and its children can be retrieved by passing variablesReference to the VariablesRequest.\nThe value should be less than or equal to 2147483647 (2^31-1)."
+								"description": "If `variablesReference` is > 0, the evaluate result is structured and its children can be retrieved by passing `variablesReference` to the `variables` request as long as execution remains suspended. See 'Lifetime of Object References' in the Overview section for details."
 							},
 							"namedVariables": {
 								"type": "integer",
-								"description": "The number of named child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31-1)."
+								"description": "The number of named child variables.\nThe client can use this information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31-1)."
 							},
 							"indexedVariables": {
 								"type": "integer",
-								"description": "The number of indexed child variables.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31-1)."
+								"description": "The number of indexed child variables.\nThe client can use this information to present the variables in a paged UI and fetch them in chunks.\nThe value should be less than or equal to 2147483647 (2^31-1)."
 							}
 						},
 						"required": [ "value" ]
@@ -2527,7 +2637,7 @@
 		"StepInTargetsRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "This request retrieves the possible stepIn targets for the specified stack frame.\nThese targets can be used in the 'stepIn' request.\nThe StepInTargets may only be called if the 'supportsStepInTargetsRequest' capability exists and is true.\nClients should only call this request if the capability 'supportsStepInTargetsRequest' is true.",
+				"description": "This request retrieves the possible step-in targets for the specified stack frame.\nThese targets can be used in the `stepIn` request.\nClients should only call this request if the corresponding capability `supportsStepInTargetsRequest` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2542,11 +2652,11 @@
 		},
 		"StepInTargetsArguments": {
 			"type": "object",
-			"description": "Arguments for 'stepInTargets' request.",
+			"description": "Arguments for `stepInTargets` request.",
 			"properties": {
 				"frameId": {
 					"type": "integer",
-					"description": "The stack frame for which to retrieve the possible stepIn targets."
+					"description": "The stack frame for which to retrieve the possible step-in targets."
 				}
 			},
 			"required": [ "frameId" ]
@@ -2554,7 +2664,7 @@
 		"StepInTargetsResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'stepInTargets' request.",
+				"description": "Response to `stepInTargets` request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -2564,7 +2674,7 @@
 								"items": {
 									"$ref": "#/definitions/StepInTarget"
 								},
-								"description": "The possible stepIn targets of the specified source location."
+								"description": "The possible step-in targets of the specified source location."
 							}
 						},
 						"required": [ "targets" ]
@@ -2577,7 +2687,7 @@
 		"GotoTargetsRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "This request retrieves the possible goto targets for the specified source location.\nThese targets can be used in the 'goto' request.\nClients should only call this request if the capability 'supportsGotoTargetsRequest' is true.",
+				"description": "This request retrieves the possible goto targets for the specified source location.\nThese targets can be used in the `goto` request.\nClients should only call this request if the corresponding capability `supportsGotoTargetsRequest` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2592,7 +2702,7 @@
 		},
 		"GotoTargetsArguments": {
 			"type": "object",
-			"description": "Arguments for 'gotoTargets' request.",
+			"description": "Arguments for `gotoTargets` request.",
 			"properties": {
 				"source": {
 					"$ref": "#/definitions/Source",
@@ -2604,7 +2714,7 @@
 				},
 				"column": {
 					"type": "integer",
-					"description": "An optional column location for which the goto targets are determined."
+					"description": "The position within `line` for which the goto targets are determined. It is measured in UTF-16 code units and the client capability `columnsStartAt1` determines whether it is 0- or 1-based."
 				}
 			},
 			"required": [ "source", "line" ]
@@ -2612,7 +2722,7 @@
 		"GotoTargetsResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'gotoTargets' request.",
+				"description": "Response to `gotoTargets` request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -2635,7 +2745,7 @@
 		"CompletionsRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Returns a list of possible completions for a given caret position and text.\nClients should only call this request if the capability 'supportsCompletionsRequest' is true.",
+				"description": "Returns a list of possible completions for a given caret position and text.\nClients should only call this request if the corresponding capability `supportsCompletionsRequest` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2650,7 +2760,7 @@
 		},
 		"CompletionsArguments": {
 			"type": "object",
-			"description": "Arguments for 'completions' request.",
+			"description": "Arguments for `completions` request.",
 			"properties": {
 				"frameId": {
 					"type": "integer",
@@ -2658,15 +2768,15 @@
 				},
 				"text": {
 					"type": "string",
-					"description": "One or more source lines. Typically this is the text a user has typed into the debug console before he asked for completion."
+					"description": "One or more source lines. Typically this is the text users have typed into the debug console before they asked for completion."
 				},
 				"column": {
 					"type": "integer",
-					"description": "The character position for which to determine the completion proposals."
+					"description": "The position within `text` for which to determine the completion proposals. It is measured in UTF-16 code units and the client capability `columnsStartAt1` determines whether it is 0- or 1-based."
 				},
 				"line": {
 					"type": "integer",
-					"description": "An optional line for which to determine the completion proposals. If missing the first line of the text is assumed."
+					"description": "A line for which to determine the completion proposals. If missing the first line of the text is assumed."
 				}
 			},
 			"required": [ "text", "column" ]
@@ -2674,7 +2784,7 @@
 		"CompletionsResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'completions' request.",
+				"description": "Response to `completions` request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -2697,7 +2807,7 @@
 		"ExceptionInfoRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Retrieves the details of the exception that caused this event to be raised.\nClients should only call this request if the capability 'supportsExceptionInfoRequest' is true.",
+				"description": "Retrieves the details of the exception that caused this event to be raised.\nClients should only call this request if the corresponding capability `supportsExceptionInfoRequest` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2712,7 +2822,7 @@
 		},
 		"ExceptionInfoArguments": {
 			"type": "object",
-			"description": "Arguments for 'exceptionInfo' request.",
+			"description": "Arguments for `exceptionInfo` request.",
 			"properties": {
 				"threadId": {
 					"type": "integer",
@@ -2724,7 +2834,7 @@
 		"ExceptionInfoResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'exceptionInfo' request.",
+				"description": "Response to `exceptionInfo` request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -2735,7 +2845,7 @@
 							},
 							"description": {
 								"type": "string",
-								"description": "Descriptive text for the exception provided by the debug adapter."
+								"description": "Descriptive text for the exception."
 							},
 							"breakMode": {
 								"$ref": "#/definitions/ExceptionBreakMode",
@@ -2756,7 +2866,7 @@
 		"ReadMemoryRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Reads bytes from memory at the provided location.\nClients should only call this request if the capability 'supportsReadMemoryRequest' is true.",
+				"description": "Reads bytes from memory at the provided location.\nClients should only call this request if the corresponding capability `supportsReadMemoryRequest` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2771,7 +2881,7 @@
 		},
 		"ReadMemoryArguments": {
 			"type": "object",
-			"description": "Arguments for 'readMemory' request.",
+			"description": "Arguments for `readMemory` request.",
 			"properties": {
 				"memoryReference": {
 					"type": "string",
@@ -2779,7 +2889,7 @@
 				},
 				"offset": {
 					"type": "integer",
-					"description": "Optional offset (in bytes) to be applied to the reference location before reading data. Can be negative."
+					"description": "Offset (in bytes) to be applied to the reference location before reading data. Can be negative."
 				},
 				"count": {
 					"type": "integer",
@@ -2791,22 +2901,22 @@
 		"ReadMemoryResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'readMemory' request.",
+				"description": "Response to `readMemory` request.",
 				"properties": {
 					"body": {
 						"type": "object",
 						"properties": {
 							"address": {
 								"type": "string",
-								"description": "The address of the first byte of data returned.\nTreated as a hex value if prefixed with '0x', or as a decimal value otherwise."
+								"description": "The address of the first byte of data returned.\nTreated as a hex value if prefixed with `0x`, or as a decimal value otherwise."
 							},
 							"unreadableBytes": {
 								"type": "integer",
-								"description": "The number of unreadable bytes encountered after the last successfully read byte.\nThis can be used to determine the number of bytes that must be skipped before a subsequent 'readMemory' request will succeed."
+								"description": "The number of unreadable bytes encountered after the last successfully read byte.\nThis can be used to determine the number of bytes that should be skipped before a subsequent `readMemory` request succeeds."
 							},
 							"data": {
 								"type": "string",
-								"description": "The bytes read from memory, encoded using base64."
+								"description": "The bytes read from memory, encoded using base64. If the decoded length of `data` is less than the requested `count` in the original `readMemory` request, and `unreadableBytes` is zero or omitted, then the client should assume it's reached the end of readable memory."
 							}
 						},
 						"required": [ "address" ]
@@ -2818,7 +2928,7 @@
 		"WriteMemoryRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Writes bytes to memory at the provided location.\nClients should only call this request if the capability 'supportsWriteMemoryRequest' is true.",
+				"description": "Writes bytes to memory at the provided location.\nClients should only call this request if the corresponding capability `supportsWriteMemoryRequest` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2833,7 +2943,7 @@
 		},
 		"WriteMemoryArguments": {
 			"type": "object",
-			"description": "Arguments for 'writeMemory' request.",
+			"description": "Arguments for `writeMemory` request.",
 			"properties": {
 				"memoryReference": {
 					"type": "string",
@@ -2841,11 +2951,11 @@
 				},
 				"offset": {
 					"type": "integer",
-					"description": "Optional offset (in bytes) to be applied to the reference location before writing data. Can be negative."
+					"description": "Offset (in bytes) to be applied to the reference location before writing data. Can be negative."
 				},
 				"allowPartial": {
 					"type": "boolean",
-					"description": "Optional property to control partial writes. If true, the debug adapter should attempt to write memory even if the entire memory region is not writable. In such a case the debug adapter should stop after hitting the first byte of memory that cannot be written and return the number of bytes written in the response via the 'offset' and 'bytesWritten' properties.\nIf false or missing, a debug adapter should attempt to verify the region is writable before writing, and fail the response if it is not."
+					"description": "Property to control partial writes. If true, the debug adapter should attempt to write memory even if the entire memory region is not writable. In such a case the debug adapter should stop after hitting the first byte of memory that cannot be written and return the number of bytes written in the response via the `offset` and `bytesWritten` properties.\nIf false or missing, a debug adapter should attempt to verify the region is writable before writing, and fail the response if it is not."
 				},
 				"data": {
 					"type": "string",
@@ -2857,18 +2967,18 @@
 		"WriteMemoryResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'writeMemory' request.",
+				"description": "Response to `writeMemory` request.",
 				"properties": {
 					"body": {
 						"type": "object",
 						"properties": {
 							"offset": {
 								"type": "integer",
-								"description": "Optional property that should be returned when 'allowPartial' is true to indicate the offset of the first byte of data successfully written. Can be negative."
+								"description": "Property that should be returned when `allowPartial` is true to indicate the offset of the first byte of data successfully written. Can be negative."
 							},
 							"bytesWritten": {
 								"type": "integer",
-								"description": "Optional property that should be returned when 'allowPartial' is true to indicate the number of bytes starting from address that were successfully written."
+								"description": "Property that should be returned when `allowPartial` is true to indicate the number of bytes starting from address that were successfully written."
 							}
 						}
 					}
@@ -2879,7 +2989,7 @@
 		"DisassembleRequest": {
 			"allOf": [ { "$ref": "#/definitions/Request" }, {
 				"type": "object",
-				"description": "Disassembles code stored at the provided location.\nClients should only call this request if the capability 'supportsDisassembleRequest' is true.",
+				"description": "Disassembles code stored at the provided location.\nClients should only call this request if the corresponding capability `supportsDisassembleRequest` is true.",
 				"properties": {
 					"command": {
 						"type": "string",
@@ -2894,7 +3004,7 @@
 		},
 		"DisassembleArguments": {
 			"type": "object",
-			"description": "Arguments for 'disassemble' request.",
+			"description": "Arguments for `disassemble` request.",
 			"properties": {
 				"memoryReference": {
 					"type": "string",
@@ -2902,11 +3012,11 @@
 				},
 				"offset": {
 					"type": "integer",
-					"description": "Optional offset (in bytes) to be applied to the reference location before disassembling. Can be negative."
+					"description": "Offset (in bytes) to be applied to the reference location before disassembling. Can be negative."
 				},
 				"instructionOffset": {
 					"type": "integer",
-					"description": "Optional offset (in instructions) to be applied after the byte offset (if any) before disassembling. Can be negative."
+					"description": "Offset (in instructions) to be applied after the byte offset (if any) before disassembling. Can be negative."
 				},
 				"instructionCount": {
 					"type": "integer",
@@ -2922,7 +3032,7 @@
 		"DisassembleResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to 'disassemble' request.",
+				"description": "Response to `disassemble` request.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -2948,7 +3058,7 @@
 			"properties": {
 				"supportsConfigurationDoneRequest": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'configurationDone' request."
+					"description": "The debug adapter supports the `configurationDone` request."
 				},
 				"supportsFunctionBreakpoints": {
 					"type": "boolean",
@@ -2964,18 +3074,18 @@
 				},
 				"supportsEvaluateForHovers": {
 					"type": "boolean",
-					"description": "The debug adapter supports a (side effect free) evaluate request for data hovers."
+					"description": "The debug adapter supports a (side effect free) `evaluate` request for data hovers."
 				},
 				"exceptionBreakpointFilters": {
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/ExceptionBreakpointsFilter"
 					},
-					"description": "Available exception filter options for the 'setExceptionBreakpoints' request."
+					"description": "Available exception filter options for the `setExceptionBreakpoints` request."
 				},
 				"supportsStepBack": {
 					"type": "boolean",
-					"description": "The debug adapter supports stepping back via the 'stepBack' and 'reverseContinue' requests."
+					"description": "The debug adapter supports stepping back via the `stepBack` and `reverseContinue` requests."
 				},
 				"supportsSetVariable": {
 					"type": "boolean",
@@ -2987,26 +3097,26 @@
 				},
 				"supportsGotoTargetsRequest": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'gotoTargets' request."
+					"description": "The debug adapter supports the `gotoTargets` request."
 				},
 				"supportsStepInTargetsRequest": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'stepInTargets' request."
+					"description": "The debug adapter supports the `stepInTargets` request."
 				},
 				"supportsCompletionsRequest": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'completions' request."
+					"description": "The debug adapter supports the `completions` request."
 				},
 				"completionTriggerCharacters": {
 					"type": "array",
 					"items": {
 						"type": "string"
 					},
-					"description": "The set of characters that should trigger completion in a REPL. If not specified, the UI should assume the '.' character."
+					"description": "The set of characters that should trigger completion in a REPL. If not specified, the UI should assume the `.` character."
 				},
 				"supportsModulesRequest": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'modules' request."
+					"description": "The debug adapter supports the `modules` request."
 				},
 				"additionalModuleColumns": {
 					"type": "array",
@@ -3024,51 +3134,51 @@
 				},
 				"supportsRestartRequest": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'restart' request. In this case a client should not implement 'restart' by terminating and relaunching the adapter but by calling the RestartRequest."
+					"description": "The debug adapter supports the `restart` request. In this case a client should not implement `restart` by terminating and relaunching the adapter but by calling the `restart` request."
 				},
 				"supportsExceptionOptions": {
 					"type": "boolean",
-					"description": "The debug adapter supports 'exceptionOptions' on the setExceptionBreakpoints request."
+					"description": "The debug adapter supports `exceptionOptions` on the `setExceptionBreakpoints` request."
 				},
 				"supportsValueFormattingOptions": {
 					"type": "boolean",
-					"description": "The debug adapter supports a 'format' attribute on the stackTraceRequest, variablesRequest, and evaluateRequest."
+					"description": "The debug adapter supports a `format` attribute on the `stackTrace`, `variables`, and `evaluate` requests."
 				},
 				"supportsExceptionInfoRequest": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'exceptionInfo' request."
+					"description": "The debug adapter supports the `exceptionInfo` request."
 				},
 				"supportTerminateDebuggee": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'terminateDebuggee' attribute on the 'disconnect' request."
+					"description": "The debug adapter supports the `terminateDebuggee` attribute on the `disconnect` request."
 				},
 				"supportSuspendDebuggee": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'suspendDebuggee' attribute on the 'disconnect' request."
+					"description": "The debug adapter supports the `suspendDebuggee` attribute on the `disconnect` request."
 				},
 				"supportsDelayedStackTraceLoading": {
 					"type": "boolean",
-					"description": "The debug adapter supports the delayed loading of parts of the stack, which requires that both the 'startFrame' and 'levels' arguments and an optional 'totalFrames' result of the 'StackTrace' request are supported."
+					"description": "The debug adapter supports the delayed loading of parts of the stack, which requires that both the `startFrame` and `levels` arguments and the `totalFrames` result of the `stackTrace` request are supported."
 				},
 				"supportsLoadedSourcesRequest": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'loadedSources' request."
+					"description": "The debug adapter supports the `loadedSources` request."
 				},
 				"supportsLogPoints": {
 					"type": "boolean",
-					"description": "The debug adapter supports logpoints by interpreting the 'logMessage' attribute of the SourceBreakpoint."
+					"description": "The debug adapter supports log points by interpreting the `logMessage` attribute of the `SourceBreakpoint`."
 				},
 				"supportsTerminateThreadsRequest": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'terminateThreads' request."
+					"description": "The debug adapter supports the `terminateThreads` request."
 				},
 				"supportsSetExpression": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'setExpression' request."
+					"description": "The debug adapter supports the `setExpression` request."
 				},
 				"supportsTerminateRequest": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'terminate' request."
+					"description": "The debug adapter supports the `terminate` request."
 				},
 				"supportsDataBreakpoints": {
 					"type": "boolean",
@@ -3076,31 +3186,31 @@
 				},
 				"supportsReadMemoryRequest": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'readMemory' request."
+					"description": "The debug adapter supports the `readMemory` request."
 				},
 				"supportsWriteMemoryRequest": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'writeMemory' request."
+					"description": "The debug adapter supports the `writeMemory` request."
 				},
 				"supportsDisassembleRequest": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'disassemble' request."
+					"description": "The debug adapter supports the `disassemble` request."
 				},
 				"supportsCancelRequest": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'cancel' request."
+					"description": "The debug adapter supports the `cancel` request."
 				},
 				"supportsBreakpointLocationsRequest": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'breakpointLocations' request."
+					"description": "The debug adapter supports the `breakpointLocations` request."
 				},
 				"supportsClipboardContext": {
 					"type": "boolean",
-					"description": "The debug adapter supports the 'clipboard' context value in the 'evaluate' request."
+					"description": "The debug adapter supports the `clipboard` context value in the `evaluate` request."
 				},
 				"supportsSteppingGranularity": {
 					"type": "boolean",
-					"description": "The debug adapter supports stepping granularities (argument 'granularity') for the stepping requests."
+					"description": "The debug adapter supports stepping granularities (argument `granularity`) for the stepping requests."
 				},
 				"supportsInstructionBreakpoints": {
 					"type": "boolean",
@@ -3108,30 +3218,34 @@
 				},
 				"supportsExceptionFilterOptions": {
 					"type": "boolean",
-					"description": "The debug adapter supports 'filterOptions' as an argument on the 'setExceptionBreakpoints' request."
+					"description": "The debug adapter supports `filterOptions` as an argument on the `setExceptionBreakpoints` request."
+				},
+				"supportsSingleThreadExecutionRequests": {
+					"type": "boolean",
+					"description": "The debug adapter supports the `singleThread` property on the execution requests (`continue`, `next`, `stepIn`, `stepOut`, `reverseContinue`, `stepBack`)."
 				}
 			}
 		},
 
 		"ExceptionBreakpointsFilter": {
 			"type": "object",
-			"description": "An ExceptionBreakpointsFilter is shown in the UI as an filter option for configuring how exceptions are dealt with.",
+			"description": "An `ExceptionBreakpointsFilter` is shown in the UI as an filter option for configuring how exceptions are dealt with.",
 			"properties": {
 				"filter": {
 					"type": "string",
-					"description": "The internal ID of the filter option. This value is passed to the 'setExceptionBreakpoints' request."
+					"description": "The internal ID of the filter option. This value is passed to the `setExceptionBreakpoints` request."
 				},
 				"label": {
 					"type": "string",
-					"description": "The name of the filter option. This will be shown in the UI."
+					"description": "The name of the filter option. This is shown in the UI."
 				},
 				"description": {
 					"type": "string",
-					"description": "An optional help text providing additional information about the exception filter. This string is typically shown as a hover and must be translated."
+					"description": "A help text providing additional information about the exception filter. This string is typically shown as a hover and can be translated."
 				},
 				"default": {
 					"type": "boolean",
-					"description": "Initial value of the filter option. If not specified a value 'false' is assumed."
+					"description": "Initial value of the filter option. If not specified a value false is assumed."
 				},
 				"supportsCondition": {
 					"type": "boolean",
@@ -3139,7 +3253,7 @@
 				},
 				"conditionDescription": {
 					"type": "string",
-					"description": "An optional help text providing information about the condition. This string is shown as the placeholder text for a text box and must be translated."
+					"description": "A help text providing information about the condition. This string is shown as the placeholder text for a text box and can be translated."
 				}
 			},
 			"required": [ "filter", "label" ]
@@ -3151,18 +3265,18 @@
 			"properties": {
 				"id": {
 					"type": "integer",
-					"description": "Unique identifier for the message."
+					"description": "Unique (within a debug adapter implementation) identifier for the message. The purpose of these error IDs is to help extension authors that have the requirement that every user visible error message needs a corresponding error number, so that users or customer support can find information about the specific error more easily."
 				},
 				"format": {
 					"type": "string",
-					"description": "A format string for the message. Embedded variables have the form '{name}'.\nIf variable name starts with an underscore character, the variable does not contain user data (PII) and can be safely used for telemetry purposes."
+					"description": "A format string for the message. Embedded variables have the form `{name}`.\nIf variable name starts with an underscore character, the variable does not contain user data (PII) and can be safely used for telemetry purposes."
 				},
 				"variables": {
 					"type": "object",
 					"description": "An object used as a dictionary for looking up the variables in the format string.",
 					"additionalProperties": {
 						"type": "string",
-						"description": "Values must be strings."
+						"description": "All dictionary values must be strings."
 					}
 				},
 				"sendTelemetry": {
@@ -3175,11 +3289,11 @@
 				},
 				"url": {
 					"type": "string",
-					"description": "An optional url where additional information about this message can be found."
+					"description": "A url where additional information about this message can be found."
 				},
 				"urlLabel": {
 					"type": "string",
-					"description": "An optional label that is presented to the user as the UI for opening the url."
+					"description": "A label that is presented to the user as the UI for opening the url."
 				}
 			},
 			"required": [ "id", "format" ]
@@ -3187,7 +3301,7 @@
 
 		"Module": {
 			"type": "object",
-			"description": "A Module object represents a row in the modules view.\nTwo attributes are mandatory: an id identifies a module in the modules view and is used in a ModuleEvent for identifying a module for adding, updating or deleting.\nThe name is used to minimally render the module in the UI.\n\nAdditional attributes can be added to the module. They will show up in the module View if they have a corresponding ColumnDescriptor.\n\nTo avoid an unnecessary proliferation of additional attributes with similar semantics but different names\nwe recommend to re-use attributes from the 'recommended' list below first, and only introduce new attributes if nothing appropriate could be found.",
+			"description": "A Module object represents a row in the modules view.\nThe `id` attribute identifies a module in the modules view and is used in a `module` event for identifying a module for adding, updating or deleting.\nThe `name` attribute is used to minimally render the module in the UI.\n\nAdditional attributes can be added to the module. They show up in the module view if they have a corresponding `ColumnDescriptor`.\n\nTo avoid an unnecessary proliferation of additional attributes with similar semantics but different names, we recommend to re-use attributes from the 'recommended' list below first, and only introduce new attributes if nothing appropriate could be found.",
 			"properties": {
 				"id": {
 					"type": ["integer", "string"],
@@ -3199,7 +3313,7 @@
 				},
 				"path": {
 					"type": "string",
-					"description": "optional but recommended attributes.\nalways try to use these first before introducing additional attributes.\n\nLogical full path to the module. The exact definition is implementation defined, but usually this would be a full path to the on-disk file for the module."
+					"description": "Logical full path to the module. The exact definition is implementation defined, but usually this would be a full path to the on-disk file for the module."
 				},
 				"isOptimized": {
 					"type": "boolean",
@@ -3215,7 +3329,7 @@
 				},
 				"symbolStatus": {
 					"type": "string",
-					"description": "User understandable description of if symbols were found for the module (ex: 'Symbols Loaded', 'Symbols not found', etc."
+					"description": "User-understandable description of if symbols were found for the module (ex: 'Symbols Loaded', 'Symbols not found', etc.)"
 				},
 				"symbolFilePath": {
 					"type": "string",
@@ -3223,7 +3337,7 @@
 				},
 				"dateTimeStamp": {
 					"type": "string",
-					"description": "Module created or modified."
+					"description": "Module created or modified, encoded as a RFC 3339 timestamp."
 				},
 				"addressRange": {
 					"type": "string",
@@ -3235,7 +3349,7 @@
 
 		"ColumnDescriptor": {
 			"type": "object",
-			"description": "A ColumnDescriptor specifies what module attribute to show in a column of the ModulesView, how to format it,\nand what the column's label should be.\nIt is only used if the underlying UI actually supports this level of customization.",
+			"description": "A `ColumnDescriptor` specifies what module attribute to show in a column of the modules view, how to format it,\nand what the column's label should be.\nIt is only used if the underlying UI actually supports this level of customization.",
 			"properties": {
 				"attributeName": {
 					"type": "string",
@@ -3252,7 +3366,7 @@
 				"type": {
 					"type": "string",
 					"enum": [ "string", "number", "boolean", "unixTimestampUTC" ],
-					"description": "Datatype of values in this column.  Defaults to 'string' if not specified."
+					"description": "Datatype of values in this column. Defaults to `string` if not specified."
 				},
 				"width": {
 					"type": "integer",
@@ -3264,7 +3378,7 @@
 
 		"ModulesViewDescriptor": {
 			"type": "object",
-			"description": "The ModulesViewDescriptor is the container for all declarative configuration options of a ModuleView.\nFor now it only specifies the columns to be shown in the modules view.",
+			"description": "The ModulesViewDescriptor is the container for all declarative configuration options of a module view.\nFor now it only specifies the columns to be shown in the modules view.",
 			"properties": {
 				"columns": {
 					"type": "array",
@@ -3286,7 +3400,7 @@
 				},
 				"name": {
 					"type": "string",
-					"description": "A name of the thread."
+					"description": "The name of the thread."
 				}
 			},
 			"required": [ "id", "name" ]
@@ -3294,7 +3408,7 @@
 
 		"Source": {
 			"type": "object",
-			"description": "A Source is a descriptor for source code.\nIt is returned from the debug adapter as part of a StackFrame and it is used by clients when specifying breakpoints.",
+			"description": "A `Source` is a descriptor for source code.\nIt is returned from the debug adapter as part of a `StackFrame` and it is used by clients when specifying breakpoints.",
 			"properties": {
 				"name": {
 					"type": "string",
@@ -3302,31 +3416,31 @@
 				},
 				"path": {
 					"type": "string",
-					"description": "The path of the source to be shown in the UI.\nIt is only used to locate and load the content of the source if no sourceReference is specified (or its value is 0)."
+					"description": "The path of the source to be shown in the UI.\nIt is only used to locate and load the content of the source if no `sourceReference` is specified (or its value is 0)."
 				},
 				"sourceReference": {
 					"type": "integer",
-					"description": "If sourceReference > 0 the contents of the source must be retrieved through the SourceRequest (even if a path is specified).\nA sourceReference is only valid for a session, so it must not be used to persist a source.\nThe value should be less than or equal to 2147483647 (2^31-1)."
+					"description": "If the value > 0 the contents of the source must be retrieved through the `source` request (even if a path is specified).\nSince a `sourceReference` is only valid for a session, it can not be used to persist a source.\nThe value should be less than or equal to 2147483647 (2^31-1)."
 				},
 				"presentationHint": {
 					"type": "string",
-					"description": "An optional hint for how to present the source in the UI.\nA value of 'deemphasize' can be used to indicate that the source is not available or that it is skipped on stepping.",
+					"description": "A hint for how to present the source in the UI.\nA value of `deemphasize` can be used to indicate that the source is not available or that it is skipped on stepping.",
 					"enum": [ "normal", "emphasize", "deemphasize" ]
 				},
 				"origin": {
 					"type": "string",
-					"description": "The (optional) origin of this source: possible values 'internal module', 'inlined content from source map', etc."
+					"description": "The origin of this source. For example, 'internal module', 'inlined content from source map', etc."
 				},
 				"sources": {
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/Source"
 					},
-					"description": "An optional list of sources that are related to this source. These may be the source that generated this source."
+					"description": "A list of sources that are related to this source. These may be the source that generated this source."
 				},
 				"adapterData": {
 					"type": [ "array", "boolean", "integer", "null", "number", "object", "string" ],
-					"description": "Optional data that a debug adapter might want to loop through the client.\nThe client should leave the data intact and persist it across sessions. The client should not interpret the data."
+					"description": "Additional data that a debug adapter might want to loop through the client.\nThe client should leave the data intact and persist it across sessions. The client should not interpret the data."
 				},
 				"checksums": {
 					"type": "array",
@@ -3344,7 +3458,7 @@
 			"properties": {
 				"id": {
 					"type": "integer",
-					"description": "An identifier for the stack frame. It must be unique across all threads.\nThis id can be used to retrieve the scopes of the frame with the 'scopesRequest' or to restart the execution of a stackframe."
+					"description": "An identifier for the stack frame. It must be unique across all threads.\nThis id can be used to retrieve the scopes of the frame with the `scopes` request or to restart the execution of a stack frame."
 				},
 				"name": {
 					"type": "string",
@@ -3352,31 +3466,31 @@
 				},
 				"source": {
 					"$ref": "#/definitions/Source",
-					"description": "The optional source of the frame."
+					"description": "The source of the frame."
 				},
 				"line": {
 					"type": "integer",
-					"description": "The line within the file of the frame. If source is null or doesn't exist, line is 0 and must be ignored."
+					"description": "The line within the source of the frame. If the source attribute is missing or doesn't exist, `line` is 0 and should be ignored by the client."
 				},
 				"column": {
 					"type": "integer",
-					"description": "The column within the line. If source is null or doesn't exist, column is 0 and must be ignored."
+					"description": "Start position of the range covered by the stack frame. It is measured in UTF-16 code units and the client capability `columnsStartAt1` determines whether it is 0- or 1-based. If attribute `source` is missing or doesn't exist, `column` is 0 and should be ignored by the client."
 				},
 				"endLine": {
 					"type": "integer",
-					"description": "An optional end line of the range covered by the stack frame."
+					"description": "The end line of the range covered by the stack frame."
 				},
 				"endColumn": {
 					"type": "integer",
-					"description": "An optional end column of the range covered by the stack frame."
+					"description": "End position of the range covered by the stack frame. It is measured in UTF-16 code units and the client capability `columnsStartAt1` determines whether it is 0- or 1-based."
 				},
 				"canRestart": {
 					"type": "boolean",
-					"description": "Indicates whether this frame can be restarted with the 'restart' request. Clients should only use this if the debug adapter supports the 'restart' request (capability 'supportsRestartRequest' is true)."
+					"description": "Indicates whether this frame can be restarted with the `restart` request. Clients should only use this if the debug adapter supports the `restart` request and the corresponding capability `supportsRestartRequest` is true. If a debug adapter has this capability, then `canRestart` defaults to `true` if the property is absent."
 				},
 				"instructionPointerReference": {
 					"type": "string",
-					"description": "Optional memory reference for the current instruction pointer in this frame."
+					"description": "A memory reference for the current instruction pointer in this frame."
 				},
 				"moduleId": {
 					"type": ["integer", "string"],
@@ -3385,7 +3499,7 @@
 				"presentationHint": {
 					"type": "string",
 					"enum": [ "normal", "label", "subtle" ],
-					"description": "An optional hint for how to present this frame in the UI.\nA value of 'label' can be used to indicate that the frame is an artificial frame that is used as a visual label or separator. A value of 'subtle' can be used to change the appearance of a frame in a 'subtle' way."
+					"description": "A hint for how to present this frame in the UI.\nA value of `label` can be used to indicate that the frame is an artificial frame that is used as a visual label or separator. A value of `subtle` can be used to change the appearance of a frame in a 'subtle' way."
 				}
 			},
 			"required": [ "id", "name", "line", "column" ]
@@ -3393,7 +3507,7 @@
 
 		"Scope": {
 			"type": "object",
-			"description": "A Scope is a named container for variables. Optionally a scope can map to a source or a range within a source.",
+			"description": "A `Scope` is a named container for variables. Optionally a scope can map to a source or a range within a source.",
 			"properties": {
 				"name": {
 					"type": "string",
@@ -3401,25 +3515,25 @@
 				},
 				"presentationHint": {
 					"type": "string",
-					"description": "An optional hint for how to present this scope in the UI. If this attribute is missing, the scope is shown with a generic UI.",
+					"description": "A hint for how to present this scope in the UI. If this attribute is missing, the scope is shown with a generic UI.",
 					"_enum": [ "arguments", "locals", "registers" ],
 					"enumDescriptions": [
 						"Scope contains method arguments.",
 						"Scope contains local variables.",
-						"Scope contains registers. Only a single 'registers' scope should be returned from a 'scopes' request."
+						"Scope contains registers. Only a single `registers` scope should be returned from a `scopes` request."
 					]
 				},
 				"variablesReference": {
 					"type": "integer",
-					"description": "The variables of this scope can be retrieved by passing the value of variablesReference to the VariablesRequest."
+					"description": "The variables of this scope can be retrieved by passing the value of `variablesReference` to the `variables` request as long as execution remains suspended. See 'Lifetime of Object References' in the Overview section for details."
 				},
 				"namedVariables": {
 					"type": "integer",
-					"description": "The number of named variables in this scope.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks."
+					"description": "The number of named variables in this scope.\nThe client can use this information to present the variables in a paged UI and fetch them in chunks."
 				},
 				"indexedVariables": {
 					"type": "integer",
-					"description": "The number of indexed variables in this scope.\nThe client can use this optional information to present the variables in a paged UI and fetch them in chunks."
+					"description": "The number of indexed variables in this scope.\nThe client can use this information to present the variables in a paged UI and fetch them in chunks."
 				},
 				"expensive": {
 					"type": "boolean",
@@ -3427,23 +3541,23 @@
 				},
 				"source": {
 					"$ref": "#/definitions/Source",
-					"description": "Optional source for this scope."
+					"description": "The source for this scope."
 				},
 				"line": {
 					"type": "integer",
-					"description": "Optional start line of the range covered by this scope."
+					"description": "The start line of the range covered by this scope."
 				},
 				"column": {
 					"type": "integer",
-					"description": "Optional start column of the range covered by this scope."
+					"description": "Start position of the range covered by the scope. It is measured in UTF-16 code units and the client capability `columnsStartAt1` determines whether it is 0- or 1-based."
 				},
 				"endLine": {
 					"type": "integer",
-					"description": "Optional end line of the range covered by this scope."
+					"description": "The end line of the range covered by this scope."
 				},
 				"endColumn": {
 					"type": "integer",
-					"description": "Optional end column of the range covered by this scope."
+					"description": "End position of the range covered by the scope. It is measured in UTF-16 code units and the client capability `columnsStartAt1` determines whether it is 0- or 1-based."
 				}
 			},
 			"required": [ "name", "variablesReference", "expensive" ]
@@ -3451,7 +3565,7 @@
 
 		"Variable": {
 			"type": "object",
-			"description": "A Variable is a name/value pair.\nOptionally a variable can have a 'type' that is shown if space permits or when hovering over the variable's name.\nAn optional 'kind' is used to render additional properties of the variable, e.g. different icons can be used to indicate that a variable is public or private.\nIf the value is structured (has children), a handle is provided to retrieve the children with the VariablesRequest.\nIf the number of named or indexed children is large, the numbers should be returned via the optional 'namedVariables' and 'indexedVariables' attributes.\nThe client can use this optional information to present the children in a paged UI and fetch them in chunks.",
+			"description": "A Variable is a name/value pair.\nThe `type` attribute is shown if space permits or when hovering over the variable's name.\nThe `kind` attribute is used to render additional properties of the variable, e.g. different icons can be used to indicate that a variable is public or private.\nIf the value is structured (has children), a handle is provided to retrieve the children with the `variables` request.\nIf the number of named or indexed children is large, the numbers should be returned via the `namedVariables` and `indexedVariables` attributes.\nThe client can use this information to present the children in a paged UI and fetch them in chunks.",
 			"properties": {
 				"name": {
 					"type": "string",
@@ -3459,11 +3573,11 @@
 				},
 				"value": {
 					"type": "string",
-					"description": "The variable's value. This can be a multi-line text, e.g. for a function the body of a function."
+					"description": "The variable's value.\nThis can be a multi-line text, e.g. for a function the body of a function.\nFor structured variables (which do not have a simple value), it is recommended to provide a one-line representation of the structured object. This helps to identify the structured object in the collapsed state when its children are not yet visible.\nAn empty string can be used if no value should be shown in the UI."
 				},
 				"type": {
 					"type": "string",
-					"description": "The type of the variable's value. Typically shown in the UI when hovering over the value.\nThis attribute should only be returned by a debug adapter if the client has passed the value true for the 'supportsVariableType' capability of the 'initialize' request."
+					"description": "The type of the variable's value. Typically shown in the UI when hovering over the value.\nThis attribute should only be returned by a debug adapter if the corresponding capability `supportsVariableType` is true."
 				},
 				"presentationHint": {
 					"$ref": "#/definitions/VariablePresentationHint",
@@ -3471,23 +3585,23 @@
 				},
 				"evaluateName": {
 					"type": "string",
-					"description": "Optional evaluatable name of this variable which can be passed to the 'EvaluateRequest' to fetch the variable's value."
+					"description": "The evaluatable name of this variable which can be passed to the `evaluate` request to fetch the variable's value."
 				},
 				"variablesReference": {
 					"type": "integer",
-					"description": "If variablesReference is > 0, the variable is structured and its children can be retrieved by passing variablesReference to the VariablesRequest."
+					"description": "If `variablesReference` is > 0, the variable is structured and its children can be retrieved by passing `variablesReference` to the `variables` request as long as execution remains suspended. See 'Lifetime of Object References' in the Overview section for details."
 				},
 				"namedVariables": {
 					"type": "integer",
-					"description": "The number of named child variables.\nThe client can use this optional information to present the children in a paged UI and fetch them in chunks."
+					"description": "The number of named child variables.\nThe client can use this information to present the children in a paged UI and fetch them in chunks."
 				},
 				"indexedVariables": {
 					"type": "integer",
-					"description": "The number of indexed child variables.\nThe client can use this optional information to present the children in a paged UI and fetch them in chunks."
+					"description": "The number of indexed child variables.\nThe client can use this information to present the children in a paged UI and fetch them in chunks."
 				},
 				"memoryReference": {
 					"type": "string",
-					"description": "Optional memory reference for the variable if the variable represents executable code, such as a function pointer.\nThis attribute is only required if the client has passed the value true for the 'supportsMemoryReferences' capability of the 'initialize' request."
+					"description": "The memory reference for the variable if the variable represents executable code, such as a function pointer.\nThis attribute is only required if the corresponding capability `supportsMemoryReferences` is true."
 				}
 			},
 			"required": [ "name", "value", "variablesReference" ]
@@ -3495,7 +3609,7 @@
 
 		"VariablePresentationHint": {
 			"type": "object",
-			"description": "Optional properties of a variable that can be used to determine how to render the variable in the UI.",
+			"description": "Properties of a variable that can be used to determine how to render the variable in the UI.",
 			"properties": {
 				"kind": {
 					"description": "The kind of variable. Before introducing additional values, try to use the listed values.",
@@ -3511,8 +3625,8 @@
 						"Indicates that the object is an inner class.",
 						"Indicates that the object is an interface.",
 						"Indicates that the object is the most derived class.",
-						"Indicates that the object is virtual, that means it is a synthetic object introducedby the\nadapter for rendering purposes, e.g. an index range for large arrays.",
-						"Deprecated: Indicates that a data breakpoint is registered for the object. The 'hasDataBreakpoint' attribute should generally be used instead."
+						"Indicates that the object is virtual, that means it is a synthetic object introduced by the adapter for rendering purposes, e.g. an index range for large arrays.",
+						"Deprecated: Indicates that a data breakpoint is registered for the object. The `hasDataBreakpoint` attribute should generally be used instead."
 					]
 				},
 				"attributes": {
@@ -3537,13 +3651,17 @@
 					"description": "Visibility of variable. Before introducing additional values, try to use the listed values.",
 					"type": "string",
 					"_enum": [ "public", "private", "protected", "internal", "final" ]
+				},
+				"lazy": {
+					"description": "If true, clients can present the variable with a UI that supports a specific gesture to trigger its evaluation.\nThis mechanism can be used for properties that require executing code when retrieving their value and where the code execution can be expensive and/or produce side-effects. A typical example are properties based on a getter function.\nPlease note that in addition to the `lazy` flag, the variable's `variablesReference` is expected to refer to a variable that will provide the value through another `variable` request.",
+					"type": "boolean"
 				}
 			}
 		},
 
 		"BreakpointLocation": {
 			"type": "object",
-			"description": "Properties of a breakpoint location returned from the 'breakpointLocations' request.",
+			"description": "Properties of a breakpoint location returned from the `breakpointLocations` request.",
 			"properties": {
 				"line": {
 					"type": "integer",
@@ -3551,15 +3669,15 @@
 				},
 				"column": {
 					"type": "integer",
-					"description": "Optional start column of breakpoint location."
+					"description": "The start position of a breakpoint location. Position is measured in UTF-16 code units and the client capability `columnsStartAt1` determines whether it is 0- or 1-based."
 				},
 				"endLine": {
 					"type": "integer",
-					"description": "Optional end line of breakpoint location if the location covers a range."
+					"description": "The end line of breakpoint location if the location covers a range."
 				},
 				"endColumn": {
 					"type": "integer",
-					"description": "Optional end column of breakpoint location if the location covers a range."
+					"description": "The end position of a breakpoint location (if the location covers a range). Position is measured in UTF-16 code units and the client capability `columnsStartAt1` determines whether it is 0- or 1-based."
 				}
 			},
 			"required": [ "line" ]
@@ -3567,7 +3685,7 @@
 
 		"SourceBreakpoint": {
 			"type": "object",
-			"description": "Properties of a breakpoint or logpoint passed to the setBreakpoints request.",
+			"description": "Properties of a breakpoint or logpoint passed to the `setBreakpoints` request.",
 			"properties": {
 				"line": {
 					"type": "integer",
@@ -3575,19 +3693,19 @@
 				},
 				"column": {
 					"type": "integer",
-					"description": "An optional source column of the breakpoint."
+					"description": "Start position within source line of the breakpoint or logpoint. It is measured in UTF-16 code units and the client capability `columnsStartAt1` determines whether it is 0- or 1-based."
 				},
 				"condition": {
 					"type": "string",
-					"description": "An optional expression for conditional breakpoints.\nIt is only honored by a debug adapter if the capability 'supportsConditionalBreakpoints' is true."
+					"description": "The expression for conditional breakpoints.\nIt is only honored by a debug adapter if the corresponding capability `supportsConditionalBreakpoints` is true."
 				},
 				"hitCondition": {
 					"type": "string",
-					"description": "An optional expression that controls how many hits of the breakpoint are ignored.\nThe backend is expected to interpret the expression as needed.\nThe attribute is only honored by a debug adapter if the capability 'supportsHitConditionalBreakpoints' is true."
+					"description": "The expression that controls how many hits of the breakpoint are ignored.\nThe debug adapter is expected to interpret the expression as needed.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportsHitConditionalBreakpoints` is true.\nIf both this property and `condition` are specified, `hitCondition` should be evaluated only if the `condition` is met, and the debug adapter should stop only if both conditions are met."
 				},
 				"logMessage": {
 					"type": "string",
-					"description": "If this attribute exists and is non-empty, the backend must not 'break' (stop)\nbut log the message instead. Expressions within {} are interpolated.\nThe attribute is only honored by a debug adapter if the capability 'supportsLogPoints' is true."
+					"description": "If this attribute exists and is non-empty, the debug adapter must not 'break' (stop)\nbut log the message instead. Expressions within `{}` are interpolated.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportsLogPoints` is true.\nIf either `hitCondition` or `condition` is specified, then the message should only be logged if those conditions are met."
 				}
 			},
 			"required": [ "line" ]
@@ -3595,7 +3713,7 @@
 
 		"FunctionBreakpoint": {
 			"type": "object",
-			"description": "Properties of a breakpoint passed to the setFunctionBreakpoints request.",
+			"description": "Properties of a breakpoint passed to the `setFunctionBreakpoints` request.",
 			"properties": {
 				"name": {
 					"type": "string",
@@ -3603,11 +3721,11 @@
 				},
 				"condition": {
 					"type": "string",
-					"description": "An optional expression for conditional breakpoints.\nIt is only honored by a debug adapter if the capability 'supportsConditionalBreakpoints' is true."
+					"description": "An expression for conditional breakpoints.\nIt is only honored by a debug adapter if the corresponding capability `supportsConditionalBreakpoints` is true."
 				},
 				"hitCondition": {
 					"type": "string",
-					"description": "An optional expression that controls how many hits of the breakpoint are ignored.\nThe backend is expected to interpret the expression as needed.\nThe attribute is only honored by a debug adapter if the capability 'supportsHitConditionalBreakpoints' is true."
+					"description": "An expression that controls how many hits of the breakpoint are ignored.\nThe debug adapter is expected to interpret the expression as needed.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportsHitConditionalBreakpoints` is true."
 				}
 			},
 			"required": [ "name" ]
@@ -3621,11 +3739,11 @@
 
 		"DataBreakpoint": {
 			"type": "object",
-			"description": "Properties of a data breakpoint passed to the setDataBreakpoints request.",
+			"description": "Properties of a data breakpoint passed to the `setDataBreakpoints` request.",
 			"properties": {
 				"dataId": {
 					"type": "string",
-					"description": "An id representing the data. This id is returned from the dataBreakpointInfo request."
+					"description": "An id representing the data. This id is returned from the `dataBreakpointInfo` request."
 				},
 				"accessType": {
 					"$ref": "#/definitions/DataBreakpointAccessType",
@@ -3633,11 +3751,11 @@
 				},
 				"condition": {
 					"type": "string",
-					"description": "An optional expression for conditional breakpoints."
+					"description": "An expression for conditional breakpoints."
 				},
 				"hitCondition": {
 					"type": "string",
-					"description": "An optional expression that controls how many hits of the breakpoint are ignored.\nThe backend is expected to interpret the expression as needed."
+					"description": "An expression that controls how many hits of the breakpoint are ignored.\nThe debug adapter is expected to interpret the expression as needed."
 				}
 			},
 			"required": [ "dataId" ]
@@ -3645,23 +3763,23 @@
 
 		"InstructionBreakpoint": {
 			"type": "object",
-			"description": "Properties of a breakpoint passed to the setInstructionBreakpoints request",
+			"description": "Properties of a breakpoint passed to the `setInstructionBreakpoints` request",
 			"properties": {
 				"instructionReference": {
 					"type": "string",
-					"description": "The instruction reference of the breakpoint.\nThis should be a memory or instruction pointer reference from an EvaluateResponse, Variable, StackFrame, GotoTarget, or Breakpoint."
+					"description": "The instruction reference of the breakpoint.\nThis should be a memory or instruction pointer reference from an `EvaluateResponse`, `Variable`, `StackFrame`, `GotoTarget`, or `Breakpoint`."
 				},
 				"offset": {
 					"type": "integer",
-					"description": "An optional offset from the instruction reference.\nThis can be negative."
+					"description": "The offset from the instruction reference.\nThis can be negative."
 				},
 				"condition": {
 					"type": "string",
-					"description": "An optional expression for conditional breakpoints.\nIt is only honored by a debug adapter if the capability 'supportsConditionalBreakpoints' is true."
+					"description": "An expression for conditional breakpoints.\nIt is only honored by a debug adapter if the corresponding capability `supportsConditionalBreakpoints` is true."
 				},
 				"hitCondition": {
 					"type": "string",
-					"description": "An optional expression that controls how many hits of the breakpoint are ignored.\nThe backend is expected to interpret the expression as needed.\nThe attribute is only honored by a debug adapter if the capability 'supportsHitConditionalBreakpoints' is true."
+					"description": "An expression that controls how many hits of the breakpoint are ignored.\nThe debug adapter is expected to interpret the expression as needed.\nThe attribute is only honored by a debug adapter if the corresponding capability `supportsHitConditionalBreakpoints` is true."
 				}
 			},
 			"required": [ "instructionReference" ]
@@ -3669,19 +3787,19 @@
 
 		"Breakpoint": {
 			"type": "object",
-			"description": "Information about a Breakpoint created in setBreakpoints, setFunctionBreakpoints, setInstructionBreakpoints, or setDataBreakpoints.",
+			"description": "Information about a breakpoint created in `setBreakpoints`, `setFunctionBreakpoints`, `setInstructionBreakpoints`, or `setDataBreakpoints` requests.",
 			"properties": {
 				"id": {
 					"type": "integer",
-					"description": "An optional identifier for the breakpoint. It is needed if breakpoint events are used to update or remove breakpoints."
+					"description": "The identifier for the breakpoint. It is needed if breakpoint events are used to update or remove breakpoints."
 				},
 				"verified": {
 					"type": "boolean",
-					"description": "If true breakpoint could be set (but not necessarily at the desired location)."
+					"description": "If true, the breakpoint could be set (but not necessarily at the desired location)."
 				},
 				"message": {
 					"type": "string",
-					"description": "An optional message about the state of the breakpoint.\nThis is shown to the user and can be used to explain why a breakpoint could not be verified."
+					"description": "A message about the state of the breakpoint.\nThis is shown to the user and can be used to explain why a breakpoint could not be verified."
 				},
 				"source": {
 					"$ref": "#/definitions/Source",
@@ -3693,23 +3811,23 @@
 				},
 				"column": {
 					"type": "integer",
-					"description": "An optional start column of the actual range covered by the breakpoint."
+					"description": "Start position of the source range covered by the breakpoint. It is measured in UTF-16 code units and the client capability `columnsStartAt1` determines whether it is 0- or 1-based."
 				},
 				"endLine": {
 					"type": "integer",
-					"description": "An optional end line of the actual range covered by the breakpoint."
+					"description": "The end line of the actual range covered by the breakpoint."
 				},
 				"endColumn": {
 					"type": "integer",
-					"description": "An optional end column of the actual range covered by the breakpoint.\nIf no end line is given, then the end column is assumed to be in the start line."
+					"description": "End position of the source range covered by the breakpoint. It is measured in UTF-16 code units and the client capability `columnsStartAt1` determines whether it is 0- or 1-based.\nIf no end line is given, then the end column is assumed to be in the start line."
 				},
 				"instructionReference": {
 					"type": "string",
-					"description": "An optional memory reference to where the breakpoint is set."
+					"description": "A memory reference to where the breakpoint is set."
 				},
 				"offset": {
 					"type": "integer",
-					"description": "An optional offset from the instruction reference.\nThis can be negative."
+					"description": "The offset from the instruction reference.\nThis can be negative."
 				}
 			},
 			"required": [ "verified" ]
@@ -3717,10 +3835,10 @@
 
 		"SteppingGranularity": {
 			"type": "string",
-			"description": "The granularity of one 'step' in the stepping requests 'next', 'stepIn', 'stepOut', and 'stepBack'.",
+			"description": "The granularity of one 'step' in the stepping requests `next`, `stepIn`, `stepOut`, and `stepBack`.",
 			"enum": [ "statement", "line", "instruction" ],
 			"enumDescriptions": [
-				"The step should allow the program to run until the current statement has finished executing.\nThe meaning of a statement is determined by the adapter and it may be considered equivalent to a line.\nFor example 'for(int i = 0; i < 10; i++) could be considered to have 3 statements 'int i = 0', 'i < 10', and 'i++'.",
+				"The step should allow the program to run until the current statement has finished executing.\nThe meaning of a statement is determined by the adapter and it may be considered equivalent to a line.\nFor example 'for(int i = 0; i < 10; i++)' could be considered to have 3 statements 'int i = 0', 'i < 10', and 'i++'.",
 				"The step should allow the program to run until the current source line has executed.",
 				"The step should allow one instruction to execute (e.g. one x86 instruction)."
 			]
@@ -3728,15 +3846,31 @@
 
 		"StepInTarget": {
 			"type": "object",
-			"description": "A StepInTarget can be used in the 'stepIn' request and determines into which single target the stepIn request should step.",
+			"description": "A `StepInTarget` can be used in the `stepIn` request and determines into which single target the `stepIn` request should step.",
 			"properties": {
 				"id": {
 					"type": "integer",
-					"description": "Unique identifier for a stepIn target."
+					"description": "Unique identifier for a step-in target."
 				},
 				"label": {
 					"type": "string",
-					"description": "The name of the stepIn target (shown in the UI)."
+					"description": "The name of the step-in target (shown in the UI)."
+				},
+				"line": {
+					"type": "integer",
+					"description": "The line of the step-in target."
+				},
+				"column": {
+					"type": "integer",
+					"description": "Start position of the range covered by the step in target. It is measured in UTF-16 code units and the client capability `columnsStartAt1` determines whether it is 0- or 1-based."
+				},
+				"endLine": {
+					"type": "integer",
+					"description": "The end line of the range covered by the step-in target."
+				},
+				"endColumn": {
+					"type": "integer",
+					"description": "End position of the range covered by the step in target. It is measured in UTF-16 code units and the client capability `columnsStartAt1` determines whether it is 0- or 1-based."
 				}
 			},
 			"required": [ "id", "label" ]
@@ -3744,11 +3878,11 @@
 
 		"GotoTarget": {
 			"type": "object",
-			"description": "A GotoTarget describes a code location that can be used as a target in the 'goto' request.\nThe possible goto targets can be determined via the 'gotoTargets' request.",
+			"description": "A `GotoTarget` describes a code location that can be used as a target in the `goto` request.\nThe possible goto targets can be determined via the `gotoTargets` request.",
 			"properties": {
 				"id": {
 					"type": "integer",
-					"description": "Unique identifier for a goto target. This is used in the goto request."
+					"description": "Unique identifier for a goto target. This is used in the `goto` request."
 				},
 				"label": {
 					"type": "string",
@@ -3760,19 +3894,19 @@
 				},
 				"column": {
 					"type": "integer",
-					"description": "An optional column of the goto target."
+					"description": "The column of the goto target."
 				},
 				"endLine": {
 					"type": "integer",
-					"description": "An optional end line of the range covered by the goto target."
+					"description": "The end line of the range covered by the goto target."
 				},
 				"endColumn": {
 					"type": "integer",
-					"description": "An optional end column of the range covered by the goto target."
+					"description": "The end column of the range covered by the goto target."
 				},
 				"instructionPointerReference": {
 					"type": "string",
-					"description": "Optional memory reference for the instruction pointer value represented by this target."
+					"description": "A memory reference for the instruction pointer value represented by this target."
 				}
 			},
 			"required": [ "id", "label", "line" ]
@@ -3780,7 +3914,7 @@
 
 		"CompletionItem": {
 			"type": "object",
-			"description": "CompletionItems are the suggestions returned from the CompletionsRequest.",
+			"description": "`CompletionItems` are the suggestions returned from the `completions` request.",
 			"properties": {
 				"label": {
 					"type": "string",
@@ -3788,11 +3922,15 @@
 				},
 				"text": {
 					"type": "string",
-					"description": "If text is not falsy then it is inserted instead of the label."
+					"description": "If text is returned and not an empty string, then it is inserted instead of the label."
 				},
 				"sortText": {
 					"type": "string",
-					"description": "A string that should be used when comparing this item with other items. When `falsy` the label is used."
+					"description": "A string that should be used when comparing this item with other items. If not returned or an empty string, the `label` is used instead."
+				},
+				"detail": {
+					"type": "string",
+					"description": "A human-readable string with additional information about this item, like type or symbol information."
 				},
 				"type": {
 					"$ref": "#/definitions/CompletionItemType",
@@ -3800,19 +3938,19 @@
 				},
 				"start": {
 					"type": "integer",
-					"description": "This value determines the location (in the CompletionsRequest's 'text' attribute) where the completion text is added.\nIf missing the text is added at the location specified by the CompletionsRequest's 'column' attribute."
+					"description": "Start position (within the `text` attribute of the `completions` request) where the completion text is added. The position is measured in UTF-16 code units and the client capability `columnsStartAt1` determines whether it is 0- or 1-based. If the start position is omitted the text is added at the location specified by the `column` attribute of the `completions` request."
 				},
 				"length": {
 					"type": "integer",
-					"description": "This value determines how many characters are overwritten by the completion text.\nIf missing the value 0 is assumed which results in the completion text being inserted."
+					"description": "Length determines how many characters are overwritten by the completion text and it is measured in UTF-16 code units. If missing the value 0 is assumed which results in the completion text being inserted."
 				},
 				"selectionStart": {
 					"type": "integer",
-					"description": "Determines the start of the new selection after the text has been inserted (or replaced).\nThe start position must in the range 0 and length of the completion text.\nIf omitted the selection starts at the end of the completion text."
+					"description": "Determines the start of the new selection after the text has been inserted (or replaced). `selectionStart` is measured in UTF-16 code units and must be in the range 0 and length of the completion text. If omitted the selection starts at the end of the completion text."
 				},
 				"selectionLength": {
 					"type": "integer",
-					"description": "Determines the length of the new selection after the text has been inserted (or replaced).\nThe selection can not extend beyond the bounds of the completion text.\nIf omitted the length is assumed to be 0."
+					"description": "Determines the length of the new selection after the text has been inserted (or replaced) and it is measured in UTF-16 code units. The selection can not extend beyond the bounds of the completion text. If omitted the length is assumed to be 0."
 				}
 			},
 			"required": [ "label" ]
@@ -3840,7 +3978,7 @@
 				},
 				"checksum": {
 					"type": "string",
-					"description": "Value of the checksum."
+					"description": "Value of the checksum, encoded as a hexadecimal value."
 				}
 			},
 			"required": [ "algorithm", "checksum" ]
@@ -3896,15 +4034,15 @@
 
 		"ExceptionFilterOptions": {
 			"type": "object",
-			"description": "An ExceptionFilterOptions is used to specify an exception filter together with a condition for the setExceptionsFilter request.",
+			"description": "An `ExceptionFilterOptions` is used to specify an exception filter together with a condition for the `setExceptionBreakpoints` request.",
 			"properties": {
 				"filterId": {
 					"type": "string",
-					"description": "ID of an exception filter returned by the 'exceptionBreakpointFilters' capability."
+					"description": "ID of an exception filter returned by the `exceptionBreakpointFilters` capability."
 				},
 				"condition": {
 					"type": "string",
-					"description": "An optional expression for conditional exceptions.\nThe exception will break into the debugger if the result of the condition is true."
+					"description": "An expression for conditional exceptions.\nThe exception breaks into the debugger if the result of the condition is true."
 				}
 			},
 			"required": [ "filterId" ]
@@ -3912,14 +4050,14 @@
 
 		"ExceptionOptions": {
 			"type": "object",
-			"description": "An ExceptionOptions assigns configuration options to a set of exceptions.",
+			"description": "An `ExceptionOptions` assigns configuration options to a set of exceptions.",
 			"properties": {
 				"path": {
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/ExceptionPathSegment"
 					},
-					"description": "A path that selects a single or multiple exceptions in a tree. If 'path' is missing, the whole tree is selected.\nBy convention the first segment of the path is a category that is used to group exceptions in the UI."
+					"description": "A path that selects a single or multiple exceptions in a tree. If `path` is missing, the whole tree is selected.\nBy convention the first segment of the path is a category that is used to group exceptions in the UI."
 				},
 				"breakMode": {
 					"$ref": "#/definitions/ExceptionBreakMode",
@@ -3937,7 +4075,7 @@
 
 		"ExceptionPathSegment": {
 			"type": "object",
-			"description": "An ExceptionPathSegment represents a segment in a path that is used to match leafs or nodes in a tree of exceptions.\nIf a segment consists of more than one name, it matches the names provided if 'negate' is false or missing or\nit matches anything except the names provided if 'negate' is true.",
+			"description": "An `ExceptionPathSegment` represents a segment in a path that is used to match leafs or nodes in a tree of exceptions.\nIf a segment consists of more than one name, it matches the names provided if `negate` is false or missing, or it matches anything except the names provided if `negate` is true.",
 			"properties": {
 				"negate": {
 					"type": "boolean",
@@ -3948,7 +4086,7 @@
 					"items": {
 						"type": "string"
 					},
-					"description": "Depending on the value of 'negate' the names that should match or not match."
+					"description": "Depending on the value of `negate` the names that should match or not match."
 				}
 			},
 			"required": [ "names" ]
@@ -3972,7 +4110,7 @@
 				},
 				"evaluateName": {
 					"type": "string",
-					"description": "Optional expression that can be evaluated in the current scope to obtain the exception object."
+					"description": "An expression that can be evaluated in the current scope to obtain the exception object."
 				},
 				"stackTrace": {
 					"type": "string",
@@ -3994,11 +4132,11 @@
 			"properties": {
 				"address": {
 					"type": "string",
-					"description": "The address of the instruction. Treated as a hex value if prefixed with '0x', or as a decimal value otherwise."
+					"description": "The address of the instruction. Treated as a hex value if prefixed with `0x`, or as a decimal value otherwise."
 				},
 				"instructionBytes": {
 					"type": "string",
-					"description": "Optional raw bytes representing the instruction and its operands, in an implementation-defined format."
+					"description": "Raw bytes representing the instruction and its operands, in an implementation-defined format."
 				},
 				"instruction": {
 					"type": "string",
@@ -4034,7 +4172,7 @@
 
 		"InvalidatedAreas": {
 			"type": "string",
-			"description": "Logical areas that can be invalidated by the 'invalidated' event.",
+			"description": "Logical areas that can be invalidated by the `invalidated` event.",
 			"_enum": [ "all", "stacks", "threads", "variables" ],
 			"enumDescriptions": [
 				"All previously fetched data has become invalid and needs to be refetched.",

--- a/cmd/gentypes/gentypes.go
+++ b/cmd/gentypes/gentypes.go
@@ -107,7 +107,10 @@ func parsePropertyType(propValue map[string]interface{}) string {
 			if !ok {
 				log.Fatal("missing additionalProperties field when type=object:", propValue)
 			}
-			valueType := parsePropertyType(additionalProps.(map[string]interface{}))
+			valueType := "interface{}"
+			if props, ok := additionalProps.(map[string]interface{}); ok {
+				valueType = parsePropertyType(props)
+			}
 			return fmt.Sprintf("map[string]%v", valueType)
 		case "interface{}":
 			return "interface{}"

--- a/schematypes.go
+++ b/schematypes.go
@@ -93,7 +93,7 @@ type Response struct {
 	Message    string `json:"message,omitempty"`
 }
 
-// ErrorResponse: On error (whenever 'success' is false), the body can provide more details.
+// ErrorResponse: On error (whenever `success` is false), the body can provide more details.
 type ErrorResponse struct {
 	Response
 
@@ -106,17 +106,16 @@ type ErrorResponseBody struct {
 
 func (r *ErrorResponse) GetResponse() *Response { return &r.Response }
 
-// CancelRequest: The 'cancel' request is used by the frontend in two situations:
+// CancelRequest: The `cancel` request is used by the client in two situations:
 // - to indicate that it is no longer interested in the result produced by a specific request issued earlier
-// - to cancel a progress sequence. Clients should only call this request if the capability 'supportsCancelRequest' is true.
-// This request has a hint characteristic: a debug adapter can only be expected to make a 'best effort' in honouring this request but there are no guarantees.
-// The 'cancel' request may return an error if it could not cancel an operation but a frontend should refrain from presenting this error to end users.
-// A frontend client should only call this request if the capability 'supportsCancelRequest' is true.
-// The request that got canceled still needs to send a response back. This can either be a normal result ('success' attribute true)
-// or an error response ('success' attribute false and the 'message' set to 'cancelled').
-// Returning partial results from a cancelled request is possible but please note that a frontend client has no generic way for detecting that a response is partial or not.
-//  The progress that got cancelled still needs to send a 'progressEnd' event back.
-//  A client should not assume that progress just got cancelled after sending the 'cancel' request.
+// - to cancel a progress sequence. Clients should only call this request if the corresponding capability `supportsCancelRequest` is true.
+// This request has a hint characteristic: a debug adapter can only be expected to make a 'best effort' in honoring this request but there are no guarantees.
+// The `cancel` request may return an error if it could not cancel an operation but a client should refrain from presenting this error to end users.
+// The request that got cancelled still needs to send a response back. This can either be a normal result (`success` attribute true) or an error response (`success` attribute false and the `message` set to `cancelled`).
+// Returning partial results from a cancelled request is possible but please note that a client has no generic way for detecting that a response is partial or not.
+// The progress that got cancelled still needs to send a `progressEnd` event back.
+//
+//	A client should not assume that progress just got cancelled after sending the `cancel` request.
 type CancelRequest struct {
 	Request
 
@@ -125,28 +124,28 @@ type CancelRequest struct {
 
 func (r *CancelRequest) GetRequest() *Request { return &r.Request }
 
-// CancelArguments: Arguments for 'cancel' request.
+// CancelArguments: Arguments for `cancel` request.
 type CancelArguments struct {
 	RequestId  int    `json:"requestId,omitempty"`
 	ProgressId string `json:"progressId,omitempty"`
 }
 
-// CancelResponse: Response to 'cancel' request. This is just an acknowledgement, so no body field is required.
+// CancelResponse: Response to `cancel` request. This is just an acknowledgement, so no body field is required.
 type CancelResponse struct {
 	Response
 }
 
 func (r *CancelResponse) GetResponse() *Response { return &r.Response }
 
-// InitializedEvent: This event indicates that the debug adapter is ready to accept configuration requests (e.g. SetBreakpointsRequest, SetExceptionBreakpointsRequest).
-// A debug adapter is expected to send this event when it is ready to accept configuration requests (but not before the 'initialize' request has finished).
+// InitializedEvent: This event indicates that the debug adapter is ready to accept configuration requests (e.g. `setBreakpoints`, `setExceptionBreakpoints`).
+// A debug adapter is expected to send this event when it is ready to accept configuration requests (but not before the `initialize` request has finished).
 // The sequence of events/requests is as follows:
-// - adapters sends 'initialized' event (after the 'initialize' request has returned)
-// - frontend sends zero or more 'setBreakpoints' requests
-// - frontend sends one 'setFunctionBreakpoints' request (if capability 'supportsFunctionBreakpoints' is true)
-// - frontend sends a 'setExceptionBreakpoints' request if one or more 'exceptionBreakpointFilters' have been defined (or if 'supportsConfigurationDoneRequest' is not defined or false)
-// - frontend sends other future configuration requests
-// - frontend sends one 'configurationDone' request to indicate the end of the configuration.
+// - adapters sends `initialized` event (after the `initialize` request has returned)
+// - client sends zero or more `setBreakpoints` requests
+// - client sends one `setFunctionBreakpoints` request (if corresponding capability `supportsFunctionBreakpoints` is true)
+// - client sends a `setExceptionBreakpoints` request if one or more `exceptionBreakpointFilters` have been defined (or if `supportsConfigurationDoneRequest` is not true)
+// - client sends other future configuration requests
+// - client sends one `configurationDone` request to indicate the end of the configuration.
 type InitializedEvent struct {
 	Event
 }
@@ -154,7 +153,7 @@ type InitializedEvent struct {
 func (e *InitializedEvent) GetEvent() *Event { return &e.Event }
 
 // StoppedEvent: The event indicates that the execution of the debuggee has stopped due to some condition.
-// This can be caused by a break point previously set, a stepping request has completed, by executing a debugger statement etc.
+// This can be caused by a breakpoint previously set, a stepping request has completed, by executing a debugger statement etc.
 type StoppedEvent struct {
 	Event
 
@@ -174,8 +173,8 @@ type StoppedEventBody struct {
 func (e *StoppedEvent) GetEvent() *Event { return &e.Event }
 
 // ContinuedEvent: The event indicates that the execution of the debuggee has continued.
-// Please note: a debug adapter is not expected to send this event in response to a request that implies that execution continues, e.g. 'launch' or 'continue'.
-// It is only necessary to send a 'continued' event if there was no previous request that implied this.
+// Please note: a debug adapter is not expected to send this event in response to a request that implies that execution continues, e.g. `launch` or `continue`.
+// It is only necessary to send a `continued` event if there was no previous request that implied this.
 type ContinuedEvent struct {
 	Event
 
@@ -309,8 +308,8 @@ type ProcessEventBody struct {
 func (e *ProcessEvent) GetEvent() *Event { return &e.Event }
 
 // CapabilitiesEvent: The event indicates that one or more capabilities have changed.
-// Since the capabilities are dependent on the frontend and its UI, it might not be possible to change that at random times (or too late).
-// Consequently this event has a hint characteristic: a frontend can only be expected to make a 'best effort' in honouring individual capabilities but there are no guarantees.
+// Since the capabilities are dependent on the client and its UI, it might not be possible to change that at random times (or too late).
+// Consequently this event has a hint characteristic: a client can only be expected to make a 'best effort' in honoring individual capabilities but there are no guarantees.
 // Only changed capabilities need to be included, all other capabilities keep their values.
 type CapabilitiesEvent struct {
 	Event
@@ -324,10 +323,9 @@ type CapabilitiesEventBody struct {
 
 func (e *CapabilitiesEvent) GetEvent() *Event { return &e.Event }
 
-// ProgressStartEvent: The event signals that a long running operation is about to start and
-// provides additional information for the client to set up a corresponding progress and cancellation UI.
+// ProgressStartEvent: The event signals that a long running operation is about to start and provides additional information for the client to set up a corresponding progress and cancellation UI.
 // The client is free to delay the showing of the UI in order to reduce flicker.
-// This event should only be sent if the client has passed the value true for the 'supportsProgressReporting' capability of the 'initialize' request.
+// This event should only be sent if the corresponding capability `supportsProgressReporting` is true.
 type ProgressStartEvent struct {
 	Event
 
@@ -345,9 +343,9 @@ type ProgressStartEventBody struct {
 
 func (e *ProgressStartEvent) GetEvent() *Event { return &e.Event }
 
-// ProgressUpdateEvent: The event signals that the progress reporting needs to updated with a new message and/or percentage.
+// ProgressUpdateEvent: The event signals that the progress reporting needs to be updated with a new message and/or percentage.
 // The client does not have to update the UI immediately, but the clients needs to keep track of the message and/or percentage values.
-// This event should only be sent if the client has passed the value true for the 'supportsProgressReporting' capability of the 'initialize' request.
+// This event should only be sent if the corresponding capability `supportsProgressReporting` is true.
 type ProgressUpdateEvent struct {
 	Event
 
@@ -362,8 +360,8 @@ type ProgressUpdateEventBody struct {
 
 func (e *ProgressUpdateEvent) GetEvent() *Event { return &e.Event }
 
-// ProgressEndEvent: The event signals the end of the progress reporting with an optional final message.
-// This event should only be sent if the client has passed the value true for the 'supportsProgressReporting' capability of the 'initialize' request.
+// ProgressEndEvent: The event signals the end of the progress reporting with a final message.
+// This event should only be sent if the corresponding capability `supportsProgressReporting` is true.
 type ProgressEndEvent struct {
 	Event
 
@@ -379,7 +377,7 @@ func (e *ProgressEndEvent) GetEvent() *Event { return &e.Event }
 
 // InvalidatedEvent: This event signals that some state in the debug adapter has changed and requires that the client needs to re-render the data snapshot previously requested.
 // Debug adapters do not have to emit this event for runtime changes like stopped or thread events because in that case the client refetches the new state anyway. But the event can be used for example to refresh the UI after rendering formatting has changed in the debug adapter.
-// This event should only be sent if the debug adapter has received a value true for the 'supportsInvalidatedEvent' capability of the 'initialize' request.
+// This event should only be sent if the corresponding capability `supportsInvalidatedEvent` is true.
 type InvalidatedEvent struct {
 	Event
 
@@ -394,9 +392,9 @@ type InvalidatedEventBody struct {
 
 func (e *InvalidatedEvent) GetEvent() *Event { return &e.Event }
 
-// MemoryEvent: This event indicates that some memory range has been updated. It should only be sent if the debug adapter has received a value true for the `supportsMemoryEvent` capability of the `initialize` request.
+// MemoryEvent: This event indicates that some memory range has been updated. It should only be sent if the corresponding capability `supportsMemoryEvent` is true.
 // Clients typically react to the event by re-issuing a `readMemory` request if they show the memory identified by the `memoryReference` and if the updated memory range overlaps the displayed range. Clients should not make assumptions how individual memory references relate to each other, so they should not assume that they are part of a single continuous address range and might overlap.
-// Debug adapters can use this event to indicate that the contents of a memory range has changed due to some other DAP request like `setVariable` or `setExpression`. Debug adapters are not expected to emit this event for each and every memory change of a running program, because that information is typically not available from debuggers and it would flood clients with too many events.
+// Debug adapters can use this event to indicate that the contents of a memory range has changed due to some other request like `setVariable` or `setExpression`. Debug adapters are not expected to emit this event for each and every memory change of a running program, because that information is typically not available from debuggers and it would flood clients with too many events.
 type MemoryEvent struct {
 	Event
 
@@ -411,9 +409,11 @@ type MemoryEventBody struct {
 
 func (e *MemoryEvent) GetEvent() *Event { return &e.Event }
 
-// RunInTerminalRequest: This optional request is sent from the debug adapter to the client to run a command in a terminal.
+// RunInTerminalRequest: This request is sent from the debug adapter to the client to run a command in a terminal.
 // This is typically used to launch the debuggee in a terminal provided by the client.
-// This request should only be called if the client has passed the value true for the 'supportsRunInTerminalRequest' capability of the 'initialize' request.
+// This request should only be called if the corresponding client capability `supportsRunInTerminalRequest` is true.
+// Client implementations of `runInTerminal` are free to run the command however they choose including issuing the command to a command line interpreter (aka 'shell'). Argument strings passed to the `runInTerminal` request must arrive verbatim in the command to be run. As a consequence, clients which use a shell are responsible for escaping any special shell characters in the argument strings to prevent them from being interpreted (and modified) by the shell.
+// Some users may wish to take advantage of shell processing in the argument strings. For clients which implement `runInTerminal` using an intermediary shell, the `argsCanBeInterpretedByShell` property can be set to true. In this case the client is requested not to escape any special shell characters in the argument strings.
 type RunInTerminalRequest struct {
 	Request
 
@@ -422,16 +422,17 @@ type RunInTerminalRequest struct {
 
 func (r *RunInTerminalRequest) GetRequest() *Request { return &r.Request }
 
-// RunInTerminalRequestArguments: Arguments for 'runInTerminal' request.
+// RunInTerminalRequestArguments: Arguments for `runInTerminal` request.
 type RunInTerminalRequestArguments struct {
-	Kind  string                 `json:"kind,omitempty"`
-	Title string                 `json:"title,omitempty"`
-	Cwd   string                 `json:"cwd"`
-	Args  []string               `json:"args"`
-	Env   map[string]interface{} `json:"env,omitempty"`
+	Kind                        string                 `json:"kind,omitempty"`
+	Title                       string                 `json:"title,omitempty"`
+	Cwd                         string                 `json:"cwd"`
+	Args                        []string               `json:"args"`
+	Env                         map[string]interface{} `json:"env,omitempty"`
+	ArgsCanBeInterpretedByShell bool                   `json:"argsCanBeInterpretedByShell,omitempty"`
 }
 
-// RunInTerminalResponse: Response to 'runInTerminal' request.
+// RunInTerminalResponse: Response to `runInTerminal` request.
 type RunInTerminalResponse struct {
 	Response
 
@@ -445,11 +446,34 @@ type RunInTerminalResponseBody struct {
 
 func (r *RunInTerminalResponse) GetResponse() *Response { return &r.Response }
 
-// InitializeRequest: The 'initialize' request is sent as the first request from the client to the debug adapter
-// in order to configure it with client capabilities and to retrieve capabilities from the debug adapter.
-// Until the debug adapter has responded to with an 'initialize' response, the client must not send any additional requests or events to the debug adapter.
-// In addition the debug adapter is not allowed to send any requests or events to the client until it has responded with an 'initialize' response.
-// The 'initialize' request may only be sent once.
+// StartDebuggingRequest: This request is sent from the debug adapter to the client to start a new debug session of the same type as the caller.
+// This request should only be sent if the corresponding client capability `supportsStartDebuggingRequest` is true.
+// A client implementation of `startDebugging` should start a new debug session (of the same type as the caller) in the same way that the caller's session was started. If the client supports hierarchical debug sessions, the newly created session can be treated as a child of the caller session.
+type StartDebuggingRequest struct {
+	Request
+
+	Arguments StartDebuggingRequestArguments `json:"arguments"`
+}
+
+func (r *StartDebuggingRequest) GetRequest() *Request { return &r.Request }
+
+// StartDebuggingRequestArguments: Arguments for `startDebugging` request.
+type StartDebuggingRequestArguments struct {
+	Configuration map[string]interface{} `json:"configuration"`
+	Request       string                 `json:"request"`
+}
+
+// StartDebuggingResponse: Response to `startDebugging` request. This is just an acknowledgement, so no body field is required.
+type StartDebuggingResponse struct {
+	Response
+}
+
+func (r *StartDebuggingResponse) GetResponse() *Response { return &r.Response }
+
+// InitializeRequest: The `initialize` request is sent as the first request from the client to the debug adapter in order to configure it with client capabilities and to retrieve capabilities from the debug adapter.
+// Until the debug adapter has responded with an `initialize` response, the client must not send any additional requests or events to the debug adapter.
+// In addition the debug adapter is not allowed to send any requests or events to the client until it has responded with an `initialize` response.
+// The `initialize` request may only be sent once.
 type InitializeRequest struct {
 	Request
 
@@ -458,25 +482,27 @@ type InitializeRequest struct {
 
 func (r *InitializeRequest) GetRequest() *Request { return &r.Request }
 
-// InitializeRequestArguments: Arguments for 'initialize' request.
+// InitializeRequestArguments: Arguments for `initialize` request.
 type InitializeRequestArguments struct {
-	ClientID                     string `json:"clientID,omitempty"`
-	ClientName                   string `json:"clientName,omitempty"`
-	AdapterID                    string `json:"adapterID"`
-	Locale                       string `json:"locale,omitempty"`
-	LinesStartAt1                bool   `json:"linesStartAt1"`
-	ColumnsStartAt1              bool   `json:"columnsStartAt1"`
-	PathFormat                   string `json:"pathFormat,omitempty"`
-	SupportsVariableType         bool   `json:"supportsVariableType,omitempty"`
-	SupportsVariablePaging       bool   `json:"supportsVariablePaging,omitempty"`
-	SupportsRunInTerminalRequest bool   `json:"supportsRunInTerminalRequest,omitempty"`
-	SupportsMemoryReferences     bool   `json:"supportsMemoryReferences,omitempty"`
-	SupportsProgressReporting    bool   `json:"supportsProgressReporting,omitempty"`
-	SupportsInvalidatedEvent     bool   `json:"supportsInvalidatedEvent,omitempty"`
-	SupportsMemoryEvent          bool   `json:"supportsMemoryEvent,omitempty"`
+	ClientID                            string `json:"clientID,omitempty"`
+	ClientName                          string `json:"clientName,omitempty"`
+	AdapterID                           string `json:"adapterID"`
+	Locale                              string `json:"locale,omitempty"`
+	LinesStartAt1                       bool   `json:"linesStartAt1"`
+	ColumnsStartAt1                     bool   `json:"columnsStartAt1"`
+	PathFormat                          string `json:"pathFormat,omitempty"`
+	SupportsVariableType                bool   `json:"supportsVariableType,omitempty"`
+	SupportsVariablePaging              bool   `json:"supportsVariablePaging,omitempty"`
+	SupportsRunInTerminalRequest        bool   `json:"supportsRunInTerminalRequest,omitempty"`
+	SupportsMemoryReferences            bool   `json:"supportsMemoryReferences,omitempty"`
+	SupportsProgressReporting           bool   `json:"supportsProgressReporting,omitempty"`
+	SupportsInvalidatedEvent            bool   `json:"supportsInvalidatedEvent,omitempty"`
+	SupportsMemoryEvent                 bool   `json:"supportsMemoryEvent,omitempty"`
+	SupportsArgsCanBeInterpretedByShell bool   `json:"supportsArgsCanBeInterpretedByShell,omitempty"`
+	SupportsStartDebuggingRequest       bool   `json:"supportsStartDebuggingRequest,omitempty"`
 }
 
-// InitializeResponse: Response to 'initialize' request.
+// InitializeResponse: Response to `initialize` request.
 type InitializeResponse struct {
 	Response
 
@@ -485,9 +511,9 @@ type InitializeResponse struct {
 
 func (r *InitializeResponse) GetResponse() *Response { return &r.Response }
 
-// ConfigurationDoneRequest: This optional request indicates that the client has finished initialization of the debug adapter.
-// So it is the last request in the sequence of configuration requests (which was started by the 'initialized' event).
-// Clients should only call this request if the capability 'supportsConfigurationDoneRequest' is true.
+// ConfigurationDoneRequest: This request indicates that the client has finished initialization of the debug adapter.
+// So it is the last request in the sequence of configuration requests (which was started by the `initialized` event).
+// Clients should only call this request if the corresponding capability `supportsConfigurationDoneRequest` is true.
 type ConfigurationDoneRequest struct {
 	Request
 
@@ -496,18 +522,18 @@ type ConfigurationDoneRequest struct {
 
 func (r *ConfigurationDoneRequest) GetRequest() *Request { return &r.Request }
 
-// ConfigurationDoneArguments: Arguments for 'configurationDone' request.
+// ConfigurationDoneArguments: Arguments for `configurationDone` request.
 type ConfigurationDoneArguments struct {
 }
 
-// ConfigurationDoneResponse: Response to 'configurationDone' request. This is just an acknowledgement, so no body field is required.
+// ConfigurationDoneResponse: Response to `configurationDone` request. This is just an acknowledgement, so no body field is required.
 type ConfigurationDoneResponse struct {
 	Response
 }
 
 func (r *ConfigurationDoneResponse) GetResponse() *Response { return &r.Response }
 
-// LaunchRequest: This launch request is sent from the client to the debug adapter to start the debuggee with or without debugging (if 'noDebug' is true).
+// LaunchRequest: This launch request is sent from the client to the debug adapter to start the debuggee with or without debugging (if `noDebug` is true).
 // Since launching is debugger/runtime specific, the arguments for this request are not part of this specification.
 type LaunchRequest struct {
 	Request
@@ -518,14 +544,14 @@ type LaunchRequest struct {
 func (r *LaunchRequest) GetRequest() *Request          { return &r.Request }
 func (r *LaunchRequest) GetArguments() json.RawMessage { return r.Arguments }
 
-// LaunchResponse: Response to 'launch' request. This is just an acknowledgement, so no body field is required.
+// LaunchResponse: Response to `launch` request. This is just an acknowledgement, so no body field is required.
 type LaunchResponse struct {
 	Response
 }
 
 func (r *LaunchResponse) GetResponse() *Response { return &r.Response }
 
-// AttachRequest: The attach request is sent from the client to the debug adapter to attach to a debuggee that is already running.
+// AttachRequest: The `attach` request is sent from the client to the debug adapter to attach to a debuggee that is already running.
 // Since attaching is debugger/runtime specific, the arguments for this request are not part of this specification.
 type AttachRequest struct {
 	Request
@@ -536,15 +562,15 @@ type AttachRequest struct {
 func (r *AttachRequest) GetRequest() *Request          { return &r.Request }
 func (r *AttachRequest) GetArguments() json.RawMessage { return r.Arguments }
 
-// AttachResponse: Response to 'attach' request. This is just an acknowledgement, so no body field is required.
+// AttachResponse: Response to `attach` request. This is just an acknowledgement, so no body field is required.
 type AttachResponse struct {
 	Response
 }
 
 func (r *AttachResponse) GetResponse() *Response { return &r.Response }
 
-// RestartRequest: Restarts a debug session. Clients should only call this request if the capability 'supportsRestartRequest' is true.
-// If the capability is missing or has the value false, a typical client will emulate 'restart' by terminating the debug adapter first and then launching it anew.
+// RestartRequest: Restarts a debug session. Clients should only call this request if the corresponding capability `supportsRestartRequest` is true.
+// If the capability is missing or has the value false, a typical client emulates `restart` by terminating the debug adapter first and then launching it anew.
 type RestartRequest struct {
 	Request
 
@@ -553,23 +579,21 @@ type RestartRequest struct {
 
 func (r *RestartRequest) GetRequest() *Request { return &r.Request }
 
-// RestartArguments: Arguments for 'restart' request.
+// RestartArguments: Arguments for `restart` request.
 type RestartArguments struct {
 	Arguments interface{} `json:"arguments,omitempty"`
 }
 
-// RestartResponse: Response to 'restart' request. This is just an acknowledgement, so no body field is required.
+// RestartResponse: Response to `restart` request. This is just an acknowledgement, so no body field is required.
 type RestartResponse struct {
 	Response
 }
 
 func (r *RestartResponse) GetResponse() *Response { return &r.Response }
 
-// DisconnectRequest: The 'disconnect' request is sent from the client to the debug adapter in order to stop debugging.
-// It asks the debug adapter to disconnect from the debuggee and to terminate the debug adapter.
-// If the debuggee has been started with the 'launch' request, the 'disconnect' request terminates the debuggee.
-// If the 'attach' request was used to connect to the debuggee, 'disconnect' does not terminate the debuggee.
-// This behavior can be controlled with the 'terminateDebuggee' argument (if supported by the debug adapter).
+// DisconnectRequest: The `disconnect` request asks the debug adapter to disconnect from the debuggee (thus ending the debug session) and then to shut down itself (the debug adapter).
+// In addition, the debug adapter must terminate the debuggee if it was started with the `launch` request. If an `attach` request was used to connect to the debuggee, then the debug adapter must not terminate the debuggee.
+// This implicit behavior of when to terminate the debuggee can be overridden with the `terminateDebuggee` argument (which is only supported by a debug adapter if the corresponding capability `supportTerminateDebuggee` is true).
 type DisconnectRequest struct {
 	Request
 
@@ -578,22 +602,24 @@ type DisconnectRequest struct {
 
 func (r *DisconnectRequest) GetRequest() *Request { return &r.Request }
 
-// DisconnectArguments: Arguments for 'disconnect' request.
+// DisconnectArguments: Arguments for `disconnect` request.
 type DisconnectArguments struct {
 	Restart           bool `json:"restart,omitempty"`
 	TerminateDebuggee bool `json:"terminateDebuggee,omitempty"`
 	SuspendDebuggee   bool `json:"suspendDebuggee,omitempty"`
 }
 
-// DisconnectResponse: Response to 'disconnect' request. This is just an acknowledgement, so no body field is required.
+// DisconnectResponse: Response to `disconnect` request. This is just an acknowledgement, so no body field is required.
 type DisconnectResponse struct {
 	Response
 }
 
 func (r *DisconnectResponse) GetResponse() *Response { return &r.Response }
 
-// TerminateRequest: The 'terminate' request is sent from the client to the debug adapter in order to give the debuggee a chance for terminating itself.
-// Clients should only call this request if the capability 'supportsTerminateRequest' is true.
+// TerminateRequest: The `terminate` request is sent from the client to the debug adapter in order to shut down the debuggee gracefully. Clients should only call this request if the capability `supportsTerminateRequest` is true.
+// Typically a debug adapter implements `terminate` by sending a software signal which the debuggee intercepts in order to clean things up properly before terminating itself.
+// Please note that this request does not directly affect the state of the debug session: if the debuggee decides to veto the graceful shutdown for any reason by not terminating itself, then the debug session just continues.
+// Clients can surface the `terminate` request as an explicit command or they can integrate it into a two stage Stop command that first sends `terminate` to request a graceful shutdown, and if that fails uses `disconnect` for a forceful shutdown.
 type TerminateRequest struct {
 	Request
 
@@ -602,20 +628,20 @@ type TerminateRequest struct {
 
 func (r *TerminateRequest) GetRequest() *Request { return &r.Request }
 
-// TerminateArguments: Arguments for 'terminate' request.
+// TerminateArguments: Arguments for `terminate` request.
 type TerminateArguments struct {
 	Restart bool `json:"restart,omitempty"`
 }
 
-// TerminateResponse: Response to 'terminate' request. This is just an acknowledgement, so no body field is required.
+// TerminateResponse: Response to `terminate` request. This is just an acknowledgement, so no body field is required.
 type TerminateResponse struct {
 	Response
 }
 
 func (r *TerminateResponse) GetResponse() *Response { return &r.Response }
 
-// BreakpointLocationsRequest: The 'breakpointLocations' request returns all possible locations for source breakpoints in a given range.
-// Clients should only call this request if the capability 'supportsBreakpointLocationsRequest' is true.
+// BreakpointLocationsRequest: The `breakpointLocations` request returns all possible locations for source breakpoints in a given range.
+// Clients should only call this request if the corresponding capability `supportsBreakpointLocationsRequest` is true.
 type BreakpointLocationsRequest struct {
 	Request
 
@@ -624,7 +650,7 @@ type BreakpointLocationsRequest struct {
 
 func (r *BreakpointLocationsRequest) GetRequest() *Request { return &r.Request }
 
-// BreakpointLocationsArguments: Arguments for 'breakpointLocations' request.
+// BreakpointLocationsArguments: Arguments for `breakpointLocations` request.
 type BreakpointLocationsArguments struct {
 	Source    Source `json:"source"`
 	Line      int    `json:"line"`
@@ -633,7 +659,7 @@ type BreakpointLocationsArguments struct {
 	EndColumn int    `json:"endColumn,omitempty"`
 }
 
-// BreakpointLocationsResponse: Response to 'breakpointLocations' request.
+// BreakpointLocationsResponse: Response to `breakpointLocations` request.
 // Contains possible locations for source breakpoints.
 type BreakpointLocationsResponse struct {
 	Response
@@ -649,7 +675,7 @@ func (r *BreakpointLocationsResponse) GetResponse() *Response { return &r.Respon
 
 // SetBreakpointsRequest: Sets multiple breakpoints for a single source and clears all previous breakpoints in that source.
 // To clear all breakpoint for a source, specify an empty array.
-// When a breakpoint is hit, a 'stopped' event (with reason 'breakpoint') is generated.
+// When a breakpoint is hit, a `stopped` event (with reason `breakpoint`) is generated.
 type SetBreakpointsRequest struct {
 	Request
 
@@ -658,7 +684,7 @@ type SetBreakpointsRequest struct {
 
 func (r *SetBreakpointsRequest) GetRequest() *Request { return &r.Request }
 
-// SetBreakpointsArguments: Arguments for 'setBreakpoints' request.
+// SetBreakpointsArguments: Arguments for `setBreakpoints` request.
 type SetBreakpointsArguments struct {
 	Source         Source             `json:"source"`
 	Breakpoints    []SourceBreakpoint `json:"breakpoints,omitempty"`
@@ -666,11 +692,11 @@ type SetBreakpointsArguments struct {
 	SourceModified bool               `json:"sourceModified,omitempty"`
 }
 
-// SetBreakpointsResponse: Response to 'setBreakpoints' request.
+// SetBreakpointsResponse: Response to `setBreakpoints` request.
 // Returned is information about each breakpoint created by this request.
 // This includes the actual code location and whether the breakpoint could be verified.
-// The breakpoints returned are in the same order as the elements of the 'breakpoints'
-// (or the deprecated 'lines') array in the arguments.
+// The breakpoints returned are in the same order as the elements of the `breakpoints`
+// (or the deprecated `lines`) array in the arguments.
 type SetBreakpointsResponse struct {
 	Response
 
@@ -685,8 +711,8 @@ func (r *SetBreakpointsResponse) GetResponse() *Response { return &r.Response }
 
 // SetFunctionBreakpointsRequest: Replaces all existing function breakpoints with new function breakpoints.
 // To clear all function breakpoints, specify an empty array.
-// When a function breakpoint is hit, a 'stopped' event (with reason 'function breakpoint') is generated.
-// Clients should only call this request if the capability 'supportsFunctionBreakpoints' is true.
+// When a function breakpoint is hit, a `stopped` event (with reason `function breakpoint`) is generated.
+// Clients should only call this request if the corresponding capability `supportsFunctionBreakpoints` is true.
 type SetFunctionBreakpointsRequest struct {
 	Request
 
@@ -695,12 +721,12 @@ type SetFunctionBreakpointsRequest struct {
 
 func (r *SetFunctionBreakpointsRequest) GetRequest() *Request { return &r.Request }
 
-// SetFunctionBreakpointsArguments: Arguments for 'setFunctionBreakpoints' request.
+// SetFunctionBreakpointsArguments: Arguments for `setFunctionBreakpoints` request.
 type SetFunctionBreakpointsArguments struct {
 	Breakpoints []FunctionBreakpoint `json:"breakpoints"`
 }
 
-// SetFunctionBreakpointsResponse: Response to 'setFunctionBreakpoints' request.
+// SetFunctionBreakpointsResponse: Response to `setFunctionBreakpoints` request.
 // Returned is information about each breakpoint created by this request.
 type SetFunctionBreakpointsResponse struct {
 	Response
@@ -714,9 +740,9 @@ type SetFunctionBreakpointsResponseBody struct {
 
 func (r *SetFunctionBreakpointsResponse) GetResponse() *Response { return &r.Response }
 
-// SetExceptionBreakpointsRequest: The request configures the debuggers response to thrown exceptions.
-// If an exception is configured to break, a 'stopped' event is fired (with reason 'exception').
-// Clients should only call this request if the capability 'exceptionBreakpointFilters' returns one or more filters.
+// SetExceptionBreakpointsRequest: The request configures the debugger's response to thrown exceptions.
+// If an exception is configured to break, a `stopped` event is fired (with reason `exception`).
+// Clients should only call this request if the corresponding capability `exceptionBreakpointFilters` returns one or more filters.
 type SetExceptionBreakpointsRequest struct {
 	Request
 
@@ -725,17 +751,17 @@ type SetExceptionBreakpointsRequest struct {
 
 func (r *SetExceptionBreakpointsRequest) GetRequest() *Request { return &r.Request }
 
-// SetExceptionBreakpointsArguments: Arguments for 'setExceptionBreakpoints' request.
+// SetExceptionBreakpointsArguments: Arguments for `setExceptionBreakpoints` request.
 type SetExceptionBreakpointsArguments struct {
 	Filters          []string                 `json:"filters"`
 	FilterOptions    []ExceptionFilterOptions `json:"filterOptions,omitempty"`
 	ExceptionOptions []ExceptionOptions       `json:"exceptionOptions,omitempty"`
 }
 
-// SetExceptionBreakpointsResponse: Response to 'setExceptionBreakpoints' request.
-// The response contains an array of Breakpoint objects with information about each exception breakpoint or filter. The Breakpoint objects are in the same order as the elements of the 'filters', 'filterOptions', 'exceptionOptions' arrays given as arguments. If both 'filters' and 'filterOptions' are given, the returned array must start with 'filters' information first, followed by 'filterOptions' information.
-// The mandatory 'verified' property of a Breakpoint object signals whether the exception breakpoint or filter could be successfully created and whether the optional condition or hit count expressions are valid. In case of an error the 'message' property explains the problem. An optional 'id' property can be used to introduce a unique ID for the exception breakpoint or filter so that it can be updated subsequently by sending breakpoint events.
-// For backward compatibility both the 'breakpoints' array and the enclosing 'body' are optional. If these elements are missing a client will not be able to show problems for individual exception breakpoints or filters.
+// SetExceptionBreakpointsResponse: Response to `setExceptionBreakpoints` request.
+// The response contains an array of `Breakpoint` objects with information about each exception breakpoint or filter. The `Breakpoint` objects are in the same order as the elements of the `filters`, `filterOptions`, `exceptionOptions` arrays given as arguments. If both `filters` and `filterOptions` are given, the returned array must start with `filters` information first, followed by `filterOptions` information.
+// The `verified` property of a `Breakpoint` object signals whether the exception breakpoint or filter could be successfully created and whether the condition or hit count expressions are valid. In case of an error the `message` property explains the problem. The `id` property can be used to introduce a unique ID for the exception breakpoint or filter so that it can be updated subsequently by sending breakpoint events.
+// For backward compatibility both the `breakpoints` array and the enclosing `body` are optional. If these elements are missing a client is not able to show problems for individual exception breakpoints or filters.
 type SetExceptionBreakpointsResponse struct {
 	Response
 
@@ -749,7 +775,7 @@ type SetExceptionBreakpointsResponseBody struct {
 func (r *SetExceptionBreakpointsResponse) GetResponse() *Response { return &r.Response }
 
 // DataBreakpointInfoRequest: Obtains information on a possible data breakpoint that could be set on an expression or variable.
-// Clients should only call this request if the capability 'supportsDataBreakpoints' is true.
+// Clients should only call this request if the corresponding capability `supportsDataBreakpoints` is true.
 type DataBreakpointInfoRequest struct {
 	Request
 
@@ -758,13 +784,14 @@ type DataBreakpointInfoRequest struct {
 
 func (r *DataBreakpointInfoRequest) GetRequest() *Request { return &r.Request }
 
-// DataBreakpointInfoArguments: Arguments for 'dataBreakpointInfo' request.
+// DataBreakpointInfoArguments: Arguments for `dataBreakpointInfo` request.
 type DataBreakpointInfoArguments struct {
 	VariablesReference int    `json:"variablesReference,omitempty"`
 	Name               string `json:"name"`
+	FrameId            int    `json:"frameId,omitempty"`
 }
 
-// DataBreakpointInfoResponse: Response to 'dataBreakpointInfo' request.
+// DataBreakpointInfoResponse: Response to `dataBreakpointInfo` request.
 type DataBreakpointInfoResponse struct {
 	Response
 
@@ -782,8 +809,8 @@ func (r *DataBreakpointInfoResponse) GetResponse() *Response { return &r.Respons
 
 // SetDataBreakpointsRequest: Replaces all existing data breakpoints with new data breakpoints.
 // To clear all data breakpoints, specify an empty array.
-// When a data breakpoint is hit, a 'stopped' event (with reason 'data breakpoint') is generated.
-// Clients should only call this request if the capability 'supportsDataBreakpoints' is true.
+// When a data breakpoint is hit, a `stopped` event (with reason `data breakpoint`) is generated.
+// Clients should only call this request if the corresponding capability `supportsDataBreakpoints` is true.
 type SetDataBreakpointsRequest struct {
 	Request
 
@@ -792,12 +819,12 @@ type SetDataBreakpointsRequest struct {
 
 func (r *SetDataBreakpointsRequest) GetRequest() *Request { return &r.Request }
 
-// SetDataBreakpointsArguments: Arguments for 'setDataBreakpoints' request.
+// SetDataBreakpointsArguments: Arguments for `setDataBreakpoints` request.
 type SetDataBreakpointsArguments struct {
 	Breakpoints []DataBreakpoint `json:"breakpoints"`
 }
 
-// SetDataBreakpointsResponse: Response to 'setDataBreakpoints' request.
+// SetDataBreakpointsResponse: Response to `setDataBreakpoints` request.
 // Returned is information about each breakpoint created by this request.
 type SetDataBreakpointsResponse struct {
 	Response
@@ -811,10 +838,10 @@ type SetDataBreakpointsResponseBody struct {
 
 func (r *SetDataBreakpointsResponse) GetResponse() *Response { return &r.Response }
 
-// SetInstructionBreakpointsRequest: Replaces all existing instruction breakpoints. Typically, instruction breakpoints would be set from a diassembly window.
+// SetInstructionBreakpointsRequest: Replaces all existing instruction breakpoints. Typically, instruction breakpoints would be set from a disassembly window.
 // To clear all instruction breakpoints, specify an empty array.
-// When an instruction breakpoint is hit, a 'stopped' event (with reason 'instruction breakpoint') is generated.
-// Clients should only call this request if the capability 'supportsInstructionBreakpoints' is true.
+// When an instruction breakpoint is hit, a `stopped` event (with reason `instruction breakpoint`) is generated.
+// Clients should only call this request if the corresponding capability `supportsInstructionBreakpoints` is true.
 type SetInstructionBreakpointsRequest struct {
 	Request
 
@@ -823,12 +850,12 @@ type SetInstructionBreakpointsRequest struct {
 
 func (r *SetInstructionBreakpointsRequest) GetRequest() *Request { return &r.Request }
 
-// SetInstructionBreakpointsArguments: Arguments for 'setInstructionBreakpoints' request
+// SetInstructionBreakpointsArguments: Arguments for `setInstructionBreakpoints` request
 type SetInstructionBreakpointsArguments struct {
 	Breakpoints []InstructionBreakpoint `json:"breakpoints"`
 }
 
-// SetInstructionBreakpointsResponse: Response to 'setInstructionBreakpoints' request
+// SetInstructionBreakpointsResponse: Response to `setInstructionBreakpoints` request
 type SetInstructionBreakpointsResponse struct {
 	Response
 
@@ -841,7 +868,7 @@ type SetInstructionBreakpointsResponseBody struct {
 
 func (r *SetInstructionBreakpointsResponse) GetResponse() *Response { return &r.Response }
 
-// ContinueRequest: The request starts the debuggee to run again.
+// ContinueRequest: The request resumes execution of all threads. If the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true resumes only the specified thread. If not all threads were resumed, the `allThreadsContinued` attribute of the response should be set to false.
 type ContinueRequest struct {
 	Request
 
@@ -850,12 +877,13 @@ type ContinueRequest struct {
 
 func (r *ContinueRequest) GetRequest() *Request { return &r.Request }
 
-// ContinueArguments: Arguments for 'continue' request.
+// ContinueArguments: Arguments for `continue` request.
 type ContinueArguments struct {
-	ThreadId int `json:"threadId"`
+	ThreadId     int  `json:"threadId"`
+	SingleThread bool `json:"singleThread,omitempty"`
 }
 
-// ContinueResponse: Response to 'continue' request.
+// ContinueResponse: Response to `continue` request.
 type ContinueResponse struct {
 	Response
 
@@ -868,8 +896,9 @@ type ContinueResponseBody struct {
 
 func (r *ContinueResponse) GetResponse() *Response { return &r.Response }
 
-// NextRequest: The request starts the debuggee to run again for one step.
-// The debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed.
+// NextRequest: The request executes one step (in the given granularity) for the specified thread and allows all other threads to run freely by resuming them.
+// If the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true prevents other suspended threads from resuming.
+// The debug adapter first sends the response and then a `stopped` event (with reason `step`) after the step has completed.
 type NextRequest struct {
 	Request
 
@@ -878,25 +907,27 @@ type NextRequest struct {
 
 func (r *NextRequest) GetRequest() *Request { return &r.Request }
 
-// NextArguments: Arguments for 'next' request.
+// NextArguments: Arguments for `next` request.
 type NextArguments struct {
-	ThreadId    int                 `json:"threadId"`
-	Granularity SteppingGranularity `json:"granularity,omitempty"`
+	ThreadId     int                 `json:"threadId"`
+	SingleThread bool                `json:"singleThread,omitempty"`
+	Granularity  SteppingGranularity `json:"granularity,omitempty"`
 }
 
-// NextResponse: Response to 'next' request. This is just an acknowledgement, so no body field is required.
+// NextResponse: Response to `next` request. This is just an acknowledgement, so no body field is required.
 type NextResponse struct {
 	Response
 }
 
 func (r *NextResponse) GetResponse() *Response { return &r.Response }
 
-// StepInRequest: The request starts the debuggee to step into a function/method if possible.
-// If it cannot step into a target, 'stepIn' behaves like 'next'.
-// The debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed.
+// StepInRequest: The request resumes the given thread to step into a function/method and allows all other threads to run freely by resuming them.
+// If the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true prevents other suspended threads from resuming.
+// If the request cannot step into a target, `stepIn` behaves like the `next` request.
+// The debug adapter first sends the response and then a `stopped` event (with reason `step`) after the step has completed.
 // If there are multiple function/method calls (or other targets) on the source line,
-// the optional argument 'targetId' can be used to control into which target the 'stepIn' should occur.
-// The list of possible targets for a given source line can be retrieved via the 'stepInTargets' request.
+// the argument `targetId` can be used to control into which target the `stepIn` should occur.
+// The list of possible targets for a given source line can be retrieved via the `stepInTargets` request.
 type StepInRequest struct {
 	Request
 
@@ -905,22 +936,24 @@ type StepInRequest struct {
 
 func (r *StepInRequest) GetRequest() *Request { return &r.Request }
 
-// StepInArguments: Arguments for 'stepIn' request.
+// StepInArguments: Arguments for `stepIn` request.
 type StepInArguments struct {
-	ThreadId    int                 `json:"threadId"`
-	TargetId    int                 `json:"targetId,omitempty"`
-	Granularity SteppingGranularity `json:"granularity,omitempty"`
+	ThreadId     int                 `json:"threadId"`
+	SingleThread bool                `json:"singleThread,omitempty"`
+	TargetId     int                 `json:"targetId,omitempty"`
+	Granularity  SteppingGranularity `json:"granularity,omitempty"`
 }
 
-// StepInResponse: Response to 'stepIn' request. This is just an acknowledgement, so no body field is required.
+// StepInResponse: Response to `stepIn` request. This is just an acknowledgement, so no body field is required.
 type StepInResponse struct {
 	Response
 }
 
 func (r *StepInResponse) GetResponse() *Response { return &r.Response }
 
-// StepOutRequest: The request starts the debuggee to run again for one step.
-// The debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed.
+// StepOutRequest: The request resumes the given thread to step out (return) from a function/method and allows all other threads to run freely by resuming them.
+// If the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true prevents other suspended threads from resuming.
+// The debug adapter first sends the response and then a `stopped` event (with reason `step`) after the step has completed.
 type StepOutRequest struct {
 	Request
 
@@ -929,22 +962,24 @@ type StepOutRequest struct {
 
 func (r *StepOutRequest) GetRequest() *Request { return &r.Request }
 
-// StepOutArguments: Arguments for 'stepOut' request.
+// StepOutArguments: Arguments for `stepOut` request.
 type StepOutArguments struct {
-	ThreadId    int                 `json:"threadId"`
-	Granularity SteppingGranularity `json:"granularity,omitempty"`
+	ThreadId     int                 `json:"threadId"`
+	SingleThread bool                `json:"singleThread,omitempty"`
+	Granularity  SteppingGranularity `json:"granularity,omitempty"`
 }
 
-// StepOutResponse: Response to 'stepOut' request. This is just an acknowledgement, so no body field is required.
+// StepOutResponse: Response to `stepOut` request. This is just an acknowledgement, so no body field is required.
 type StepOutResponse struct {
 	Response
 }
 
 func (r *StepOutResponse) GetResponse() *Response { return &r.Response }
 
-// StepBackRequest: The request starts the debuggee to run one step backwards.
-// The debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed.
-// Clients should only call this request if the capability 'supportsStepBack' is true.
+// StepBackRequest: The request executes one backward step (in the given granularity) for the specified thread and allows all other threads to run backward freely by resuming them.
+// If the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true prevents other suspended threads from resuming.
+// The debug adapter first sends the response and then a `stopped` event (with reason `step`) after the step has completed.
+// Clients should only call this request if the corresponding capability `supportsStepBack` is true.
 type StepBackRequest struct {
 	Request
 
@@ -953,21 +988,22 @@ type StepBackRequest struct {
 
 func (r *StepBackRequest) GetRequest() *Request { return &r.Request }
 
-// StepBackArguments: Arguments for 'stepBack' request.
+// StepBackArguments: Arguments for `stepBack` request.
 type StepBackArguments struct {
-	ThreadId    int                 `json:"threadId"`
-	Granularity SteppingGranularity `json:"granularity,omitempty"`
+	ThreadId     int                 `json:"threadId"`
+	SingleThread bool                `json:"singleThread,omitempty"`
+	Granularity  SteppingGranularity `json:"granularity,omitempty"`
 }
 
-// StepBackResponse: Response to 'stepBack' request. This is just an acknowledgement, so no body field is required.
+// StepBackResponse: Response to `stepBack` request. This is just an acknowledgement, so no body field is required.
 type StepBackResponse struct {
 	Response
 }
 
 func (r *StepBackResponse) GetResponse() *Response { return &r.Response }
 
-// ReverseContinueRequest: The request starts the debuggee to run backward.
-// Clients should only call this request if the capability 'supportsStepBack' is true.
+// ReverseContinueRequest: The request resumes backward execution of all threads. If the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true resumes only the specified thread. If not all threads were resumed, the `allThreadsContinued` attribute of the response should be set to false.
+// Clients should only call this request if the corresponding capability `supportsStepBack` is true.
 type ReverseContinueRequest struct {
 	Request
 
@@ -976,21 +1012,22 @@ type ReverseContinueRequest struct {
 
 func (r *ReverseContinueRequest) GetRequest() *Request { return &r.Request }
 
-// ReverseContinueArguments: Arguments for 'reverseContinue' request.
+// ReverseContinueArguments: Arguments for `reverseContinue` request.
 type ReverseContinueArguments struct {
-	ThreadId int `json:"threadId"`
+	ThreadId     int  `json:"threadId"`
+	SingleThread bool `json:"singleThread,omitempty"`
 }
 
-// ReverseContinueResponse: Response to 'reverseContinue' request. This is just an acknowledgement, so no body field is required.
+// ReverseContinueResponse: Response to `reverseContinue` request. This is just an acknowledgement, so no body field is required.
 type ReverseContinueResponse struct {
 	Response
 }
 
 func (r *ReverseContinueResponse) GetResponse() *Response { return &r.Response }
 
-// RestartFrameRequest: The request restarts execution of the specified stackframe.
-// The debug adapter first sends the response and then a 'stopped' event (with reason 'restart') after the restart has completed.
-// Clients should only call this request if the capability 'supportsRestartFrame' is true.
+// RestartFrameRequest: The request restarts execution of the specified stack frame.
+// The debug adapter first sends the response and then a `stopped` event (with reason `restart`) after the restart has completed.
+// Clients should only call this request if the corresponding capability `supportsRestartFrame` is true.
 type RestartFrameRequest struct {
 	Request
 
@@ -999,12 +1036,12 @@ type RestartFrameRequest struct {
 
 func (r *RestartFrameRequest) GetRequest() *Request { return &r.Request }
 
-// RestartFrameArguments: Arguments for 'restartFrame' request.
+// RestartFrameArguments: Arguments for `restartFrame` request.
 type RestartFrameArguments struct {
 	FrameId int `json:"frameId"`
 }
 
-// RestartFrameResponse: Response to 'restartFrame' request. This is just an acknowledgement, so no body field is required.
+// RestartFrameResponse: Response to `restartFrame` request. This is just an acknowledgement, so no body field is required.
 type RestartFrameResponse struct {
 	Response
 }
@@ -1012,10 +1049,10 @@ type RestartFrameResponse struct {
 func (r *RestartFrameResponse) GetResponse() *Response { return &r.Response }
 
 // GotoRequest: The request sets the location where the debuggee will continue to run.
-// This makes it possible to skip the execution of code or to executed code again.
+// This makes it possible to skip the execution of code or to execute code again.
 // The code between the current location and the goto target is not executed but skipped.
-// The debug adapter first sends the response and then a 'stopped' event with reason 'goto'.
-// Clients should only call this request if the capability 'supportsGotoTargetsRequest' is true (because only then goto targets exist that can be passed as arguments).
+// The debug adapter first sends the response and then a `stopped` event with reason `goto`.
+// Clients should only call this request if the corresponding capability `supportsGotoTargetsRequest` is true (because only then goto targets exist that can be passed as arguments).
 type GotoRequest struct {
 	Request
 
@@ -1024,13 +1061,13 @@ type GotoRequest struct {
 
 func (r *GotoRequest) GetRequest() *Request { return &r.Request }
 
-// GotoArguments: Arguments for 'goto' request.
+// GotoArguments: Arguments for `goto` request.
 type GotoArguments struct {
 	ThreadId int `json:"threadId"`
 	TargetId int `json:"targetId"`
 }
 
-// GotoResponse: Response to 'goto' request. This is just an acknowledgement, so no body field is required.
+// GotoResponse: Response to `goto` request. This is just an acknowledgement, so no body field is required.
 type GotoResponse struct {
 	Response
 }
@@ -1038,7 +1075,7 @@ type GotoResponse struct {
 func (r *GotoResponse) GetResponse() *Response { return &r.Response }
 
 // PauseRequest: The request suspends the debuggee.
-// The debug adapter first sends the response and then a 'stopped' event (with reason 'pause') after the thread has been paused successfully.
+// The debug adapter first sends the response and then a `stopped` event (with reason `pause`) after the thread has been paused successfully.
 type PauseRequest struct {
 	Request
 
@@ -1047,12 +1084,12 @@ type PauseRequest struct {
 
 func (r *PauseRequest) GetRequest() *Request { return &r.Request }
 
-// PauseArguments: Arguments for 'pause' request.
+// PauseArguments: Arguments for `pause` request.
 type PauseArguments struct {
 	ThreadId int `json:"threadId"`
 }
 
-// PauseResponse: Response to 'pause' request. This is just an acknowledgement, so no body field is required.
+// PauseResponse: Response to `pause` request. This is just an acknowledgement, so no body field is required.
 type PauseResponse struct {
 	Response
 }
@@ -1060,7 +1097,7 @@ type PauseResponse struct {
 func (r *PauseResponse) GetResponse() *Response { return &r.Response }
 
 // StackTraceRequest: The request returns a stacktrace from the current execution state of a given thread.
-// A client can request all stack frames by omitting the startFrame and levels arguments. For performance conscious clients and if the debug adapter's 'supportsDelayedStackTraceLoading' capability is true, stack frames can be retrieved in a piecemeal way with the startFrame and levels arguments. The response of the stackTrace request may contain a totalFrames property that hints at the total number of frames in the stack. If a client needs this total number upfront, it can issue a request for a single (first) frame and depending on the value of totalFrames decide how to proceed. In any case a client should be prepared to receive less frames than requested, which is an indication that the end of the stack has been reached.
+// A client can request all stack frames by omitting the startFrame and levels arguments. For performance-conscious clients and if the corresponding capability `supportsDelayedStackTraceLoading` is true, stack frames can be retrieved in a piecemeal way with the `startFrame` and `levels` arguments. The response of the `stackTrace` request may contain a `totalFrames` property that hints at the total number of frames in the stack. If a client needs this total number upfront, it can issue a request for a single (first) frame and depending on the value of `totalFrames` decide how to proceed. In any case a client should be prepared to receive fewer frames than requested, which is an indication that the end of the stack has been reached.
 type StackTraceRequest struct {
 	Request
 
@@ -1069,7 +1106,7 @@ type StackTraceRequest struct {
 
 func (r *StackTraceRequest) GetRequest() *Request { return &r.Request }
 
-// StackTraceArguments: Arguments for 'stackTrace' request.
+// StackTraceArguments: Arguments for `stackTrace` request.
 type StackTraceArguments struct {
 	ThreadId   int              `json:"threadId"`
 	StartFrame int              `json:"startFrame,omitempty"`
@@ -1077,7 +1114,7 @@ type StackTraceArguments struct {
 	Format     StackFrameFormat `json:"format,omitempty"`
 }
 
-// StackTraceResponse: Response to 'stackTrace' request.
+// StackTraceResponse: Response to `stackTrace` request.
 type StackTraceResponse struct {
 	Response
 
@@ -1091,7 +1128,7 @@ type StackTraceResponseBody struct {
 
 func (r *StackTraceResponse) GetResponse() *Response { return &r.Response }
 
-// ScopesRequest: The request returns the variable scopes for a given stackframe ID.
+// ScopesRequest: The request returns the variable scopes for a given stack frame ID.
 type ScopesRequest struct {
 	Request
 
@@ -1100,12 +1137,12 @@ type ScopesRequest struct {
 
 func (r *ScopesRequest) GetRequest() *Request { return &r.Request }
 
-// ScopesArguments: Arguments for 'scopes' request.
+// ScopesArguments: Arguments for `scopes` request.
 type ScopesArguments struct {
 	FrameId int `json:"frameId"`
 }
 
-// ScopesResponse: Response to 'scopes' request.
+// ScopesResponse: Response to `scopes` request.
 type ScopesResponse struct {
 	Response
 
@@ -1119,7 +1156,7 @@ type ScopesResponseBody struct {
 func (r *ScopesResponse) GetResponse() *Response { return &r.Response }
 
 // VariablesRequest: Retrieves all child variables for the given variable reference.
-// An optional filter can be used to limit the fetched children to either named or indexed children.
+// A filter can be used to limit the fetched children to either named or indexed children.
 type VariablesRequest struct {
 	Request
 
@@ -1128,7 +1165,7 @@ type VariablesRequest struct {
 
 func (r *VariablesRequest) GetRequest() *Request { return &r.Request }
 
-// VariablesArguments: Arguments for 'variables' request.
+// VariablesArguments: Arguments for `variables` request.
 type VariablesArguments struct {
 	VariablesReference int         `json:"variablesReference"`
 	Filter             string      `json:"filter,omitempty"`
@@ -1137,7 +1174,7 @@ type VariablesArguments struct {
 	Format             ValueFormat `json:"format,omitempty"`
 }
 
-// VariablesResponse: Response to 'variables' request.
+// VariablesResponse: Response to `variables` request.
 type VariablesResponse struct {
 	Response
 
@@ -1150,8 +1187,8 @@ type VariablesResponseBody struct {
 
 func (r *VariablesResponse) GetResponse() *Response { return &r.Response }
 
-// SetVariableRequest: Set the variable with the given name in the variable container to a new value. Clients should only call this request if the capability 'supportsSetVariable' is true.
-// If a debug adapter implements both setVariable and setExpression, a client will only use setExpression if the variable has an evaluateName property.
+// SetVariableRequest: Set the variable with the given name in the variable container to a new value. Clients should only call this request if the corresponding capability `supportsSetVariable` is true.
+// If a debug adapter implements both `setVariable` and `setExpression`, a client will only use `setExpression` if the variable has an `evaluateName` property.
 type SetVariableRequest struct {
 	Request
 
@@ -1160,7 +1197,7 @@ type SetVariableRequest struct {
 
 func (r *SetVariableRequest) GetRequest() *Request { return &r.Request }
 
-// SetVariableArguments: Arguments for 'setVariable' request.
+// SetVariableArguments: Arguments for `setVariable` request.
 type SetVariableArguments struct {
 	VariablesReference int         `json:"variablesReference"`
 	Name               string      `json:"name"`
@@ -1168,7 +1205,7 @@ type SetVariableArguments struct {
 	Format             ValueFormat `json:"format,omitempty"`
 }
 
-// SetVariableResponse: Response to 'setVariable' request.
+// SetVariableResponse: Response to `setVariable` request.
 type SetVariableResponse struct {
 	Response
 
@@ -1194,13 +1231,13 @@ type SourceRequest struct {
 
 func (r *SourceRequest) GetRequest() *Request { return &r.Request }
 
-// SourceArguments: Arguments for 'source' request.
+// SourceArguments: Arguments for `source` request.
 type SourceArguments struct {
 	Source          Source `json:"source,omitempty"`
 	SourceReference int    `json:"sourceReference"`
 }
 
-// SourceResponse: Response to 'source' request.
+// SourceResponse: Response to `source` request.
 type SourceResponse struct {
 	Response
 
@@ -1221,7 +1258,7 @@ type ThreadsRequest struct {
 
 func (r *ThreadsRequest) GetRequest() *Request { return &r.Request }
 
-// ThreadsResponse: Response to 'threads' request.
+// ThreadsResponse: Response to `threads` request.
 type ThreadsResponse struct {
 	Response
 
@@ -1235,7 +1272,7 @@ type ThreadsResponseBody struct {
 func (r *ThreadsResponse) GetResponse() *Response { return &r.Response }
 
 // TerminateThreadsRequest: The request terminates the threads with the given ids.
-// Clients should only call this request if the capability 'supportsTerminateThreadsRequest' is true.
+// Clients should only call this request if the corresponding capability `supportsTerminateThreadsRequest` is true.
 type TerminateThreadsRequest struct {
 	Request
 
@@ -1244,12 +1281,12 @@ type TerminateThreadsRequest struct {
 
 func (r *TerminateThreadsRequest) GetRequest() *Request { return &r.Request }
 
-// TerminateThreadsArguments: Arguments for 'terminateThreads' request.
+// TerminateThreadsArguments: Arguments for `terminateThreads` request.
 type TerminateThreadsArguments struct {
 	ThreadIds []int `json:"threadIds,omitempty"`
 }
 
-// TerminateThreadsResponse: Response to 'terminateThreads' request. This is just an acknowledgement, so no body field is required.
+// TerminateThreadsResponse: Response to `terminateThreads` request. This is just an acknowledgement, no body field is required.
 type TerminateThreadsResponse struct {
 	Response
 }
@@ -1257,7 +1294,7 @@ type TerminateThreadsResponse struct {
 func (r *TerminateThreadsResponse) GetResponse() *Response { return &r.Response }
 
 // ModulesRequest: Modules can be retrieved from the debug adapter with this request which can either return all modules or a range of modules to support paging.
-// Clients should only call this request if the capability 'supportsModulesRequest' is true.
+// Clients should only call this request if the corresponding capability `supportsModulesRequest` is true.
 type ModulesRequest struct {
 	Request
 
@@ -1266,13 +1303,13 @@ type ModulesRequest struct {
 
 func (r *ModulesRequest) GetRequest() *Request { return &r.Request }
 
-// ModulesArguments: Arguments for 'modules' request.
+// ModulesArguments: Arguments for `modules` request.
 type ModulesArguments struct {
 	StartModule int `json:"startModule,omitempty"`
 	ModuleCount int `json:"moduleCount,omitempty"`
 }
 
-// ModulesResponse: Response to 'modules' request.
+// ModulesResponse: Response to `modules` request.
 type ModulesResponse struct {
 	Response
 
@@ -1287,7 +1324,7 @@ type ModulesResponseBody struct {
 func (r *ModulesResponse) GetResponse() *Response { return &r.Response }
 
 // LoadedSourcesRequest: Retrieves the set of all sources currently loaded by the debugged process.
-// Clients should only call this request if the capability 'supportsLoadedSourcesRequest' is true.
+// Clients should only call this request if the corresponding capability `supportsLoadedSourcesRequest` is true.
 type LoadedSourcesRequest struct {
 	Request
 
@@ -1296,11 +1333,11 @@ type LoadedSourcesRequest struct {
 
 func (r *LoadedSourcesRequest) GetRequest() *Request { return &r.Request }
 
-// LoadedSourcesArguments: Arguments for 'loadedSources' request.
+// LoadedSourcesArguments: Arguments for `loadedSources` request.
 type LoadedSourcesArguments struct {
 }
 
-// LoadedSourcesResponse: Response to 'loadedSources' request.
+// LoadedSourcesResponse: Response to `loadedSources` request.
 type LoadedSourcesResponse struct {
 	Response
 
@@ -1313,7 +1350,7 @@ type LoadedSourcesResponseBody struct {
 
 func (r *LoadedSourcesResponse) GetResponse() *Response { return &r.Response }
 
-// EvaluateRequest: Evaluates the given expression in the context of the top most stack frame.
+// EvaluateRequest: Evaluates the given expression in the context of the topmost stack frame.
 // The expression has access to any variables and arguments that are in scope.
 type EvaluateRequest struct {
 	Request
@@ -1323,7 +1360,7 @@ type EvaluateRequest struct {
 
 func (r *EvaluateRequest) GetRequest() *Request { return &r.Request }
 
-// EvaluateArguments: Arguments for 'evaluate' request.
+// EvaluateArguments: Arguments for `evaluate` request.
 type EvaluateArguments struct {
 	Expression string      `json:"expression"`
 	FrameId    int         `json:"frameId,omitempty"`
@@ -1331,7 +1368,7 @@ type EvaluateArguments struct {
 	Format     ValueFormat `json:"format,omitempty"`
 }
 
-// EvaluateResponse: Response to 'evaluate' request.
+// EvaluateResponse: Response to `evaluate` request.
 type EvaluateResponse struct {
 	Response
 
@@ -1350,10 +1387,10 @@ type EvaluateResponseBody struct {
 
 func (r *EvaluateResponse) GetResponse() *Response { return &r.Response }
 
-// SetExpressionRequest: Evaluates the given 'value' expression and assigns it to the 'expression' which must be a modifiable l-value.
+// SetExpressionRequest: Evaluates the given `value` expression and assigns it to the `expression` which must be a modifiable l-value.
 // The expressions have access to any variables and arguments that are in scope of the specified frame.
-// Clients should only call this request if the capability 'supportsSetExpression' is true.
-// If a debug adapter implements both setExpression and setVariable, a client will only use setExpression if the variable has an evaluateName property.
+// Clients should only call this request if the corresponding capability `supportsSetExpression` is true.
+// If a debug adapter implements both `setExpression` and `setVariable`, a client uses `setExpression` if the variable has an `evaluateName` property.
 type SetExpressionRequest struct {
 	Request
 
@@ -1362,7 +1399,7 @@ type SetExpressionRequest struct {
 
 func (r *SetExpressionRequest) GetRequest() *Request { return &r.Request }
 
-// SetExpressionArguments: Arguments for 'setExpression' request.
+// SetExpressionArguments: Arguments for `setExpression` request.
 type SetExpressionArguments struct {
 	Expression string      `json:"expression"`
 	Value      string      `json:"value"`
@@ -1370,7 +1407,7 @@ type SetExpressionArguments struct {
 	Format     ValueFormat `json:"format,omitempty"`
 }
 
-// SetExpressionResponse: Response to 'setExpression' request.
+// SetExpressionResponse: Response to `setExpression` request.
 type SetExpressionResponse struct {
 	Response
 
@@ -1388,10 +1425,9 @@ type SetExpressionResponseBody struct {
 
 func (r *SetExpressionResponse) GetResponse() *Response { return &r.Response }
 
-// StepInTargetsRequest: This request retrieves the possible stepIn targets for the specified stack frame.
-// These targets can be used in the 'stepIn' request.
-// The StepInTargets may only be called if the 'supportsStepInTargetsRequest' capability exists and is true.
-// Clients should only call this request if the capability 'supportsStepInTargetsRequest' is true.
+// StepInTargetsRequest: This request retrieves the possible step-in targets for the specified stack frame.
+// These targets can be used in the `stepIn` request.
+// Clients should only call this request if the corresponding capability `supportsStepInTargetsRequest` is true.
 type StepInTargetsRequest struct {
 	Request
 
@@ -1400,12 +1436,12 @@ type StepInTargetsRequest struct {
 
 func (r *StepInTargetsRequest) GetRequest() *Request { return &r.Request }
 
-// StepInTargetsArguments: Arguments for 'stepInTargets' request.
+// StepInTargetsArguments: Arguments for `stepInTargets` request.
 type StepInTargetsArguments struct {
 	FrameId int `json:"frameId"`
 }
 
-// StepInTargetsResponse: Response to 'stepInTargets' request.
+// StepInTargetsResponse: Response to `stepInTargets` request.
 type StepInTargetsResponse struct {
 	Response
 
@@ -1419,8 +1455,8 @@ type StepInTargetsResponseBody struct {
 func (r *StepInTargetsResponse) GetResponse() *Response { return &r.Response }
 
 // GotoTargetsRequest: This request retrieves the possible goto targets for the specified source location.
-// These targets can be used in the 'goto' request.
-// Clients should only call this request if the capability 'supportsGotoTargetsRequest' is true.
+// These targets can be used in the `goto` request.
+// Clients should only call this request if the corresponding capability `supportsGotoTargetsRequest` is true.
 type GotoTargetsRequest struct {
 	Request
 
@@ -1429,14 +1465,14 @@ type GotoTargetsRequest struct {
 
 func (r *GotoTargetsRequest) GetRequest() *Request { return &r.Request }
 
-// GotoTargetsArguments: Arguments for 'gotoTargets' request.
+// GotoTargetsArguments: Arguments for `gotoTargets` request.
 type GotoTargetsArguments struct {
 	Source Source `json:"source"`
 	Line   int    `json:"line"`
 	Column int    `json:"column,omitempty"`
 }
 
-// GotoTargetsResponse: Response to 'gotoTargets' request.
+// GotoTargetsResponse: Response to `gotoTargets` request.
 type GotoTargetsResponse struct {
 	Response
 
@@ -1450,7 +1486,7 @@ type GotoTargetsResponseBody struct {
 func (r *GotoTargetsResponse) GetResponse() *Response { return &r.Response }
 
 // CompletionsRequest: Returns a list of possible completions for a given caret position and text.
-// Clients should only call this request if the capability 'supportsCompletionsRequest' is true.
+// Clients should only call this request if the corresponding capability `supportsCompletionsRequest` is true.
 type CompletionsRequest struct {
 	Request
 
@@ -1459,7 +1495,7 @@ type CompletionsRequest struct {
 
 func (r *CompletionsRequest) GetRequest() *Request { return &r.Request }
 
-// CompletionsArguments: Arguments for 'completions' request.
+// CompletionsArguments: Arguments for `completions` request.
 type CompletionsArguments struct {
 	FrameId int    `json:"frameId,omitempty"`
 	Text    string `json:"text"`
@@ -1467,7 +1503,7 @@ type CompletionsArguments struct {
 	Line    int    `json:"line,omitempty"`
 }
 
-// CompletionsResponse: Response to 'completions' request.
+// CompletionsResponse: Response to `completions` request.
 type CompletionsResponse struct {
 	Response
 
@@ -1481,7 +1517,7 @@ type CompletionsResponseBody struct {
 func (r *CompletionsResponse) GetResponse() *Response { return &r.Response }
 
 // ExceptionInfoRequest: Retrieves the details of the exception that caused this event to be raised.
-// Clients should only call this request if the capability 'supportsExceptionInfoRequest' is true.
+// Clients should only call this request if the corresponding capability `supportsExceptionInfoRequest` is true.
 type ExceptionInfoRequest struct {
 	Request
 
@@ -1490,12 +1526,12 @@ type ExceptionInfoRequest struct {
 
 func (r *ExceptionInfoRequest) GetRequest() *Request { return &r.Request }
 
-// ExceptionInfoArguments: Arguments for 'exceptionInfo' request.
+// ExceptionInfoArguments: Arguments for `exceptionInfo` request.
 type ExceptionInfoArguments struct {
 	ThreadId int `json:"threadId"`
 }
 
-// ExceptionInfoResponse: Response to 'exceptionInfo' request.
+// ExceptionInfoResponse: Response to `exceptionInfo` request.
 type ExceptionInfoResponse struct {
 	Response
 
@@ -1512,7 +1548,7 @@ type ExceptionInfoResponseBody struct {
 func (r *ExceptionInfoResponse) GetResponse() *Response { return &r.Response }
 
 // ReadMemoryRequest: Reads bytes from memory at the provided location.
-// Clients should only call this request if the capability 'supportsReadMemoryRequest' is true.
+// Clients should only call this request if the corresponding capability `supportsReadMemoryRequest` is true.
 type ReadMemoryRequest struct {
 	Request
 
@@ -1521,14 +1557,14 @@ type ReadMemoryRequest struct {
 
 func (r *ReadMemoryRequest) GetRequest() *Request { return &r.Request }
 
-// ReadMemoryArguments: Arguments for 'readMemory' request.
+// ReadMemoryArguments: Arguments for `readMemory` request.
 type ReadMemoryArguments struct {
 	MemoryReference string `json:"memoryReference"`
 	Offset          int    `json:"offset,omitempty"`
 	Count           int    `json:"count"`
 }
 
-// ReadMemoryResponse: Response to 'readMemory' request.
+// ReadMemoryResponse: Response to `readMemory` request.
 type ReadMemoryResponse struct {
 	Response
 
@@ -1544,7 +1580,7 @@ type ReadMemoryResponseBody struct {
 func (r *ReadMemoryResponse) GetResponse() *Response { return &r.Response }
 
 // WriteMemoryRequest: Writes bytes to memory at the provided location.
-// Clients should only call this request if the capability 'supportsWriteMemoryRequest' is true.
+// Clients should only call this request if the corresponding capability `supportsWriteMemoryRequest` is true.
 type WriteMemoryRequest struct {
 	Request
 
@@ -1553,7 +1589,7 @@ type WriteMemoryRequest struct {
 
 func (r *WriteMemoryRequest) GetRequest() *Request { return &r.Request }
 
-// WriteMemoryArguments: Arguments for 'writeMemory' request.
+// WriteMemoryArguments: Arguments for `writeMemory` request.
 type WriteMemoryArguments struct {
 	MemoryReference string `json:"memoryReference"`
 	Offset          int    `json:"offset,omitempty"`
@@ -1561,7 +1597,7 @@ type WriteMemoryArguments struct {
 	Data            string `json:"data"`
 }
 
-// WriteMemoryResponse: Response to 'writeMemory' request.
+// WriteMemoryResponse: Response to `writeMemory` request.
 type WriteMemoryResponse struct {
 	Response
 
@@ -1576,7 +1612,7 @@ type WriteMemoryResponseBody struct {
 func (r *WriteMemoryResponse) GetResponse() *Response { return &r.Response }
 
 // DisassembleRequest: Disassembles code stored at the provided location.
-// Clients should only call this request if the capability 'supportsDisassembleRequest' is true.
+// Clients should only call this request if the corresponding capability `supportsDisassembleRequest` is true.
 type DisassembleRequest struct {
 	Request
 
@@ -1585,7 +1621,7 @@ type DisassembleRequest struct {
 
 func (r *DisassembleRequest) GetRequest() *Request { return &r.Request }
 
-// DisassembleArguments: Arguments for 'disassemble' request.
+// DisassembleArguments: Arguments for `disassemble` request.
 type DisassembleArguments struct {
 	MemoryReference   string `json:"memoryReference"`
 	Offset            int    `json:"offset,omitempty"`
@@ -1594,7 +1630,7 @@ type DisassembleArguments struct {
 	ResolveSymbols    bool   `json:"resolveSymbols,omitempty"`
 }
 
-// DisassembleResponse: Response to 'disassemble' request.
+// DisassembleResponse: Response to `disassemble` request.
 type DisassembleResponse struct {
 	Response
 
@@ -1609,47 +1645,48 @@ func (r *DisassembleResponse) GetResponse() *Response { return &r.Response }
 
 // Capabilities: Information about the capabilities of a debug adapter.
 type Capabilities struct {
-	SupportsConfigurationDoneRequest   bool                         `json:"supportsConfigurationDoneRequest,omitempty"`
-	SupportsFunctionBreakpoints        bool                         `json:"supportsFunctionBreakpoints,omitempty"`
-	SupportsConditionalBreakpoints     bool                         `json:"supportsConditionalBreakpoints,omitempty"`
-	SupportsHitConditionalBreakpoints  bool                         `json:"supportsHitConditionalBreakpoints,omitempty"`
-	SupportsEvaluateForHovers          bool                         `json:"supportsEvaluateForHovers,omitempty"`
-	ExceptionBreakpointFilters         []ExceptionBreakpointsFilter `json:"exceptionBreakpointFilters,omitempty"`
-	SupportsStepBack                   bool                         `json:"supportsStepBack,omitempty"`
-	SupportsSetVariable                bool                         `json:"supportsSetVariable,omitempty"`
-	SupportsRestartFrame               bool                         `json:"supportsRestartFrame,omitempty"`
-	SupportsGotoTargetsRequest         bool                         `json:"supportsGotoTargetsRequest,omitempty"`
-	SupportsStepInTargetsRequest       bool                         `json:"supportsStepInTargetsRequest,omitempty"`
-	SupportsCompletionsRequest         bool                         `json:"supportsCompletionsRequest,omitempty"`
-	CompletionTriggerCharacters        []string                     `json:"completionTriggerCharacters,omitempty"`
-	SupportsModulesRequest             bool                         `json:"supportsModulesRequest,omitempty"`
-	AdditionalModuleColumns            []ColumnDescriptor           `json:"additionalModuleColumns,omitempty"`
-	SupportedChecksumAlgorithms        []ChecksumAlgorithm          `json:"supportedChecksumAlgorithms,omitempty"`
-	SupportsRestartRequest             bool                         `json:"supportsRestartRequest,omitempty"`
-	SupportsExceptionOptions           bool                         `json:"supportsExceptionOptions,omitempty"`
-	SupportsValueFormattingOptions     bool                         `json:"supportsValueFormattingOptions,omitempty"`
-	SupportsExceptionInfoRequest       bool                         `json:"supportsExceptionInfoRequest,omitempty"`
-	SupportTerminateDebuggee           bool                         `json:"supportTerminateDebuggee,omitempty"`
-	SupportSuspendDebuggee             bool                         `json:"supportSuspendDebuggee,omitempty"`
-	SupportsDelayedStackTraceLoading   bool                         `json:"supportsDelayedStackTraceLoading,omitempty"`
-	SupportsLoadedSourcesRequest       bool                         `json:"supportsLoadedSourcesRequest,omitempty"`
-	SupportsLogPoints                  bool                         `json:"supportsLogPoints,omitempty"`
-	SupportsTerminateThreadsRequest    bool                         `json:"supportsTerminateThreadsRequest,omitempty"`
-	SupportsSetExpression              bool                         `json:"supportsSetExpression,omitempty"`
-	SupportsTerminateRequest           bool                         `json:"supportsTerminateRequest,omitempty"`
-	SupportsDataBreakpoints            bool                         `json:"supportsDataBreakpoints,omitempty"`
-	SupportsReadMemoryRequest          bool                         `json:"supportsReadMemoryRequest,omitempty"`
-	SupportsWriteMemoryRequest         bool                         `json:"supportsWriteMemoryRequest,omitempty"`
-	SupportsDisassembleRequest         bool                         `json:"supportsDisassembleRequest,omitempty"`
-	SupportsCancelRequest              bool                         `json:"supportsCancelRequest,omitempty"`
-	SupportsBreakpointLocationsRequest bool                         `json:"supportsBreakpointLocationsRequest,omitempty"`
-	SupportsClipboardContext           bool                         `json:"supportsClipboardContext,omitempty"`
-	SupportsSteppingGranularity        bool                         `json:"supportsSteppingGranularity,omitempty"`
-	SupportsInstructionBreakpoints     bool                         `json:"supportsInstructionBreakpoints,omitempty"`
-	SupportsExceptionFilterOptions     bool                         `json:"supportsExceptionFilterOptions,omitempty"`
+	SupportsConfigurationDoneRequest      bool                         `json:"supportsConfigurationDoneRequest,omitempty"`
+	SupportsFunctionBreakpoints           bool                         `json:"supportsFunctionBreakpoints,omitempty"`
+	SupportsConditionalBreakpoints        bool                         `json:"supportsConditionalBreakpoints,omitempty"`
+	SupportsHitConditionalBreakpoints     bool                         `json:"supportsHitConditionalBreakpoints,omitempty"`
+	SupportsEvaluateForHovers             bool                         `json:"supportsEvaluateForHovers,omitempty"`
+	ExceptionBreakpointFilters            []ExceptionBreakpointsFilter `json:"exceptionBreakpointFilters,omitempty"`
+	SupportsStepBack                      bool                         `json:"supportsStepBack,omitempty"`
+	SupportsSetVariable                   bool                         `json:"supportsSetVariable,omitempty"`
+	SupportsRestartFrame                  bool                         `json:"supportsRestartFrame,omitempty"`
+	SupportsGotoTargetsRequest            bool                         `json:"supportsGotoTargetsRequest,omitempty"`
+	SupportsStepInTargetsRequest          bool                         `json:"supportsStepInTargetsRequest,omitempty"`
+	SupportsCompletionsRequest            bool                         `json:"supportsCompletionsRequest,omitempty"`
+	CompletionTriggerCharacters           []string                     `json:"completionTriggerCharacters,omitempty"`
+	SupportsModulesRequest                bool                         `json:"supportsModulesRequest,omitempty"`
+	AdditionalModuleColumns               []ColumnDescriptor           `json:"additionalModuleColumns,omitempty"`
+	SupportedChecksumAlgorithms           []ChecksumAlgorithm          `json:"supportedChecksumAlgorithms,omitempty"`
+	SupportsRestartRequest                bool                         `json:"supportsRestartRequest,omitempty"`
+	SupportsExceptionOptions              bool                         `json:"supportsExceptionOptions,omitempty"`
+	SupportsValueFormattingOptions        bool                         `json:"supportsValueFormattingOptions,omitempty"`
+	SupportsExceptionInfoRequest          bool                         `json:"supportsExceptionInfoRequest,omitempty"`
+	SupportTerminateDebuggee              bool                         `json:"supportTerminateDebuggee,omitempty"`
+	SupportSuspendDebuggee                bool                         `json:"supportSuspendDebuggee,omitempty"`
+	SupportsDelayedStackTraceLoading      bool                         `json:"supportsDelayedStackTraceLoading,omitempty"`
+	SupportsLoadedSourcesRequest          bool                         `json:"supportsLoadedSourcesRequest,omitempty"`
+	SupportsLogPoints                     bool                         `json:"supportsLogPoints,omitempty"`
+	SupportsTerminateThreadsRequest       bool                         `json:"supportsTerminateThreadsRequest,omitempty"`
+	SupportsSetExpression                 bool                         `json:"supportsSetExpression,omitempty"`
+	SupportsTerminateRequest              bool                         `json:"supportsTerminateRequest,omitempty"`
+	SupportsDataBreakpoints               bool                         `json:"supportsDataBreakpoints,omitempty"`
+	SupportsReadMemoryRequest             bool                         `json:"supportsReadMemoryRequest,omitempty"`
+	SupportsWriteMemoryRequest            bool                         `json:"supportsWriteMemoryRequest,omitempty"`
+	SupportsDisassembleRequest            bool                         `json:"supportsDisassembleRequest,omitempty"`
+	SupportsCancelRequest                 bool                         `json:"supportsCancelRequest,omitempty"`
+	SupportsBreakpointLocationsRequest    bool                         `json:"supportsBreakpointLocationsRequest,omitempty"`
+	SupportsClipboardContext              bool                         `json:"supportsClipboardContext,omitempty"`
+	SupportsSteppingGranularity           bool                         `json:"supportsSteppingGranularity,omitempty"`
+	SupportsInstructionBreakpoints        bool                         `json:"supportsInstructionBreakpoints,omitempty"`
+	SupportsExceptionFilterOptions        bool                         `json:"supportsExceptionFilterOptions,omitempty"`
+	SupportsSingleThreadExecutionRequests bool                         `json:"supportsSingleThreadExecutionRequests,omitempty"`
 }
 
-// ExceptionBreakpointsFilter: An ExceptionBreakpointsFilter is shown in the UI as an filter option for configuring how exceptions are dealt with.
+// ExceptionBreakpointsFilter: An `ExceptionBreakpointsFilter` is shown in the UI as an filter option for configuring how exceptions are dealt with.
 type ExceptionBreakpointsFilter struct {
 	Filter               string `json:"filter"`
 	Label                string `json:"label"`
@@ -1671,13 +1708,12 @@ type ErrorMessage struct {
 }
 
 // Module: A Module object represents a row in the modules view.
-// Two attributes are mandatory: an id identifies a module in the modules view and is used in a ModuleEvent for identifying a module for adding, updating or deleting.
-// The name is used to minimally render the module in the UI.
+// The `id` attribute identifies a module in the modules view and is used in a `module` event for identifying a module for adding, updating or deleting.
+// The `name` attribute is used to minimally render the module in the UI.
 //
-// Additional attributes can be added to the module. They will show up in the module View if they have a corresponding ColumnDescriptor.
+// Additional attributes can be added to the module. They show up in the module view if they have a corresponding `ColumnDescriptor`.
 //
-// To avoid an unnecessary proliferation of additional attributes with similar semantics but different names
-// we recommend to re-use attributes from the 'recommended' list below first, and only introduce new attributes if nothing appropriate could be found.
+// To avoid an unnecessary proliferation of additional attributes with similar semantics but different names, we recommend to re-use attributes from the 'recommended' list below first, and only introduce new attributes if nothing appropriate could be found.
 type Module struct {
 	Id             interface{} `json:"id"`
 	Name           string      `json:"name"`
@@ -1691,7 +1727,7 @@ type Module struct {
 	AddressRange   string      `json:"addressRange,omitempty"`
 }
 
-// ColumnDescriptor: A ColumnDescriptor specifies what module attribute to show in a column of the ModulesView, how to format it,
+// ColumnDescriptor: A `ColumnDescriptor` specifies what module attribute to show in a column of the modules view, how to format it,
 // and what the column's label should be.
 // It is only used if the underlying UI actually supports this level of customization.
 type ColumnDescriptor struct {
@@ -1702,7 +1738,7 @@ type ColumnDescriptor struct {
 	Width         int    `json:"width,omitempty"`
 }
 
-// ModulesViewDescriptor: The ModulesViewDescriptor is the container for all declarative configuration options of a ModuleView.
+// ModulesViewDescriptor: The ModulesViewDescriptor is the container for all declarative configuration options of a module view.
 // For now it only specifies the columns to be shown in the modules view.
 type ModulesViewDescriptor struct {
 	Columns []ColumnDescriptor `json:"columns"`
@@ -1714,8 +1750,8 @@ type Thread struct {
 	Name string `json:"name"`
 }
 
-// Source: A Source is a descriptor for source code.
-// It is returned from the debug adapter as part of a StackFrame and it is used by clients when specifying breakpoints.
+// Source: A `Source` is a descriptor for source code.
+// It is returned from the debug adapter as part of a `StackFrame` and it is used by clients when specifying breakpoints.
 type Source struct {
 	Name             string      `json:"name,omitempty"`
 	Path             string      `json:"path,omitempty"`
@@ -1742,7 +1778,7 @@ type StackFrame struct {
 	PresentationHint            string      `json:"presentationHint,omitempty"`
 }
 
-// Scope: A Scope is a named container for variables. Optionally a scope can map to a source or a range within a source.
+// Scope: A `Scope` is a named container for variables. Optionally a scope can map to a source or a range within a source.
 type Scope struct {
 	Name               string `json:"name"`
 	PresentationHint   string `json:"presentationHint,omitempty"`
@@ -1758,11 +1794,11 @@ type Scope struct {
 }
 
 // Variable: A Variable is a name/value pair.
-// Optionally a variable can have a 'type' that is shown if space permits or when hovering over the variable's name.
-// An optional 'kind' is used to render additional properties of the variable, e.g. different icons can be used to indicate that a variable is public or private.
-// If the value is structured (has children), a handle is provided to retrieve the children with the VariablesRequest.
-// If the number of named or indexed children is large, the numbers should be returned via the optional 'namedVariables' and 'indexedVariables' attributes.
-// The client can use this optional information to present the children in a paged UI and fetch them in chunks.
+// The `type` attribute is shown if space permits or when hovering over the variable's name.
+// The `kind` attribute is used to render additional properties of the variable, e.g. different icons can be used to indicate that a variable is public or private.
+// If the value is structured (has children), a handle is provided to retrieve the children with the `variables` request.
+// If the number of named or indexed children is large, the numbers should be returned via the `namedVariables` and `indexedVariables` attributes.
+// The client can use this information to present the children in a paged UI and fetch them in chunks.
 type Variable struct {
 	Name               string                   `json:"name"`
 	Value              string                   `json:"value"`
@@ -1775,14 +1811,15 @@ type Variable struct {
 	MemoryReference    string                   `json:"memoryReference,omitempty"`
 }
 
-// VariablePresentationHint: Optional properties of a variable that can be used to determine how to render the variable in the UI.
+// VariablePresentationHint: Properties of a variable that can be used to determine how to render the variable in the UI.
 type VariablePresentationHint struct {
 	Kind       string   `json:"kind,omitempty"`
 	Attributes []string `json:"attributes,omitempty"`
 	Visibility string   `json:"visibility,omitempty"`
+	Lazy       bool     `json:"lazy,omitempty"`
 }
 
-// BreakpointLocation: Properties of a breakpoint location returned from the 'breakpointLocations' request.
+// BreakpointLocation: Properties of a breakpoint location returned from the `breakpointLocations` request.
 type BreakpointLocation struct {
 	Line      int `json:"line"`
 	Column    int `json:"column,omitempty"`
@@ -1790,7 +1827,7 @@ type BreakpointLocation struct {
 	EndColumn int `json:"endColumn,omitempty"`
 }
 
-// SourceBreakpoint: Properties of a breakpoint or logpoint passed to the setBreakpoints request.
+// SourceBreakpoint: Properties of a breakpoint or logpoint passed to the `setBreakpoints` request.
 type SourceBreakpoint struct {
 	Line         int    `json:"line"`
 	Column       int    `json:"column,omitempty"`
@@ -1799,7 +1836,7 @@ type SourceBreakpoint struct {
 	LogMessage   string `json:"logMessage,omitempty"`
 }
 
-// FunctionBreakpoint: Properties of a breakpoint passed to the setFunctionBreakpoints request.
+// FunctionBreakpoint: Properties of a breakpoint passed to the `setFunctionBreakpoints` request.
 type FunctionBreakpoint struct {
 	Name         string `json:"name"`
 	Condition    string `json:"condition,omitempty"`
@@ -1809,7 +1846,7 @@ type FunctionBreakpoint struct {
 // DataBreakpointAccessType: This enumeration defines all possible access types for data breakpoints.
 type DataBreakpointAccessType string
 
-// DataBreakpoint: Properties of a data breakpoint passed to the setDataBreakpoints request.
+// DataBreakpoint: Properties of a data breakpoint passed to the `setDataBreakpoints` request.
 type DataBreakpoint struct {
 	DataId       string                   `json:"dataId"`
 	AccessType   DataBreakpointAccessType `json:"accessType,omitempty"`
@@ -1817,7 +1854,7 @@ type DataBreakpoint struct {
 	HitCondition string                   `json:"hitCondition,omitempty"`
 }
 
-// InstructionBreakpoint: Properties of a breakpoint passed to the setInstructionBreakpoints request
+// InstructionBreakpoint: Properties of a breakpoint passed to the `setInstructionBreakpoints` request
 type InstructionBreakpoint struct {
 	InstructionReference string `json:"instructionReference"`
 	Offset               int    `json:"offset,omitempty"`
@@ -1825,7 +1862,7 @@ type InstructionBreakpoint struct {
 	HitCondition         string `json:"hitCondition,omitempty"`
 }
 
-// Breakpoint: Information about a Breakpoint created in setBreakpoints, setFunctionBreakpoints, setInstructionBreakpoints, or setDataBreakpoints.
+// Breakpoint: Information about a breakpoint created in `setBreakpoints`, `setFunctionBreakpoints`, `setInstructionBreakpoints`, or `setDataBreakpoints` requests.
 type Breakpoint struct {
 	Id                   int     `json:"id,omitempty"`
 	Verified             bool    `json:"verified"`
@@ -1839,17 +1876,21 @@ type Breakpoint struct {
 	Offset               int     `json:"offset,omitempty"`
 }
 
-// SteppingGranularity: The granularity of one 'step' in the stepping requests 'next', 'stepIn', 'stepOut', and 'stepBack'.
+// SteppingGranularity: The granularity of one 'step' in the stepping requests `next`, `stepIn`, `stepOut`, and `stepBack`.
 type SteppingGranularity string
 
-// StepInTarget: A StepInTarget can be used in the 'stepIn' request and determines into which single target the stepIn request should step.
+// StepInTarget: A `StepInTarget` can be used in the `stepIn` request and determines into which single target the `stepIn` request should step.
 type StepInTarget struct {
-	Id    int    `json:"id"`
-	Label string `json:"label"`
+	Id        int    `json:"id"`
+	Label     string `json:"label"`
+	Line      int    `json:"line,omitempty"`
+	Column    int    `json:"column,omitempty"`
+	EndLine   int    `json:"endLine,omitempty"`
+	EndColumn int    `json:"endColumn,omitempty"`
 }
 
-// GotoTarget: A GotoTarget describes a code location that can be used as a target in the 'goto' request.
-// The possible goto targets can be determined via the 'gotoTargets' request.
+// GotoTarget: A `GotoTarget` describes a code location that can be used as a target in the `goto` request.
+// The possible goto targets can be determined via the `gotoTargets` request.
 type GotoTarget struct {
 	Id                          int    `json:"id"`
 	Label                       string `json:"label"`
@@ -1860,11 +1901,12 @@ type GotoTarget struct {
 	InstructionPointerReference string `json:"instructionPointerReference,omitempty"`
 }
 
-// CompletionItem: CompletionItems are the suggestions returned from the CompletionsRequest.
+// CompletionItem: `CompletionItems` are the suggestions returned from the `completions` request.
 type CompletionItem struct {
 	Label           string             `json:"label"`
 	Text            string             `json:"text,omitempty"`
 	SortText        string             `json:"sortText,omitempty"`
+	Detail          string             `json:"detail,omitempty"`
 	Type            CompletionItemType `json:"type,omitempty"`
 	Start           int                `json:"start,omitempty"`
 	Length          int                `json:"length,omitempty"`
@@ -1902,13 +1944,13 @@ type StackFrameFormat struct {
 	IncludeAll      bool `json:"includeAll,omitempty"`
 }
 
-// ExceptionFilterOptions: An ExceptionFilterOptions is used to specify an exception filter together with a condition for the setExceptionsFilter request.
+// ExceptionFilterOptions: An `ExceptionFilterOptions` is used to specify an exception filter together with a condition for the `setExceptionBreakpoints` request.
 type ExceptionFilterOptions struct {
 	FilterId  string `json:"filterId"`
 	Condition string `json:"condition,omitempty"`
 }
 
-// ExceptionOptions: An ExceptionOptions assigns configuration options to a set of exceptions.
+// ExceptionOptions: An `ExceptionOptions` assigns configuration options to a set of exceptions.
 type ExceptionOptions struct {
 	Path      []ExceptionPathSegment `json:"path,omitempty"`
 	BreakMode ExceptionBreakMode     `json:"breakMode"`
@@ -1921,9 +1963,8 @@ type ExceptionOptions struct {
 // userUnhandled: breaks if the exception is not handled by user code.
 type ExceptionBreakMode string
 
-// ExceptionPathSegment: An ExceptionPathSegment represents a segment in a path that is used to match leafs or nodes in a tree of exceptions.
-// If a segment consists of more than one name, it matches the names provided if 'negate' is false or missing or
-// it matches anything except the names provided if 'negate' is true.
+// ExceptionPathSegment: An `ExceptionPathSegment` represents a segment in a path that is used to match leafs or nodes in a tree of exceptions.
+// If a segment consists of more than one name, it matches the names provided if `negate` is false or missing, or it matches anything except the names provided if `negate` is true.
 type ExceptionPathSegment struct {
 	Negate bool     `json:"negate,omitempty"`
 	Names  []string `json:"names"`
@@ -1952,14 +1993,15 @@ type DisassembledInstruction struct {
 	EndColumn        int    `json:"endColumn,omitempty"`
 }
 
-// InvalidatedAreas: Logical areas that can be invalidated by the 'invalidated' event.
+// InvalidatedAreas: Logical areas that can be invalidated by the `invalidated` event.
 type InvalidatedAreas string
 
 // Mapping of request commands and corresponding struct constructors that
 // can be passed to json.Unmarshal.
 var requestCtor = map[string]messageCtor{
-	"cancel":        func() Message { return &CancelRequest{} },
-	"runInTerminal": func() Message { return &RunInTerminalRequest{} },
+	"cancel":         func() Message { return &CancelRequest{} },
+	"runInTerminal":  func() Message { return &RunInTerminalRequest{} },
+	"startDebugging": func() Message { return &StartDebuggingRequest{} },
 	"initialize": func() Message {
 		return &InitializeRequest{
 			Arguments: InitializeRequestArguments{
@@ -2017,6 +2059,7 @@ var requestCtor = map[string]messageCtor{
 var responseCtor = map[string]messageCtor{
 	"cancel":                    func() Message { return &CancelResponse{} },
 	"runInTerminal":             func() Message { return &RunInTerminalResponse{} },
+	"startDebugging":            func() Message { return &StartDebuggingResponse{} },
 	"initialize":                func() Message { return &InitializeResponse{} },
 	"configurationDone":         func() Message { return &ConfigurationDoneResponse{} },
 	"launch":                    func() Message { return &LaunchResponse{} },


### PR DESCRIPTION
This change includes the following notable changes:

- A lot of documentation updates. Unfortunately, the comments are not well formatted according to Go style.
- A new `StartDebugging` request. This one is a reverse request that instructs the client to start a debug session. Its JSON schema used `additionalProperties: true`, which needed a special case in gentypes.go
- Support for halting only a single thread instead of all threads.

Fixes #68