### PR TITLE
Optimize message parsing

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -108,73 +108,70 @@ func (c *Codec) RegisterEvent(event string, ctor func() Message) error {
 // command, etc cannot be cast, returns DecodeProtocolMessageFieldError.
 // See also godoc for json.Unmarshal, which is used for underlying decoding.
 func (c *Codec) DecodeMessage(data []byte) (Message, error) {
-	var protomsg ProtocolMessage
-	if err := json.Unmarshal(data, &protomsg); err != nil {
+	var m struct {
+		Seq     int    `json:"seq"`
+		Type    string `json:"type"`
+		Event   string `json:"event"`
+		Success bool   `json:"success"`
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
 		return nil, err
 	}
-	switch protomsg.Type {
+	switch m.Type {
 	case "request":
-		return c.decodeRequest(data)
+		return c.decodeRequest(m.Command, m.Seq, data)
 	case "response":
-		return c.decodeResponse(data)
+		return c.decodeResponse(m.Command, m.Seq, m.Success, data)
 	case "event":
-		return c.decodeEvent(data)
+		return c.decodeEvent(m.Event, m.Seq, data)
 	default:
-		return nil, &DecodeProtocolMessageFieldError{protomsg.GetSeq(), "ProtocolMessage", "type", protomsg.Type}
+		return nil, &DecodeProtocolMessageFieldError{m.Seq, "ProtocolMessage", "type", m.Type}
 	}
 }
 
 // decodeRequest determines what request type in the ProtocolMessage hierarchy
 // data corresponds to and uses json.Unmarshal to populate the corresponding
 // struct to be returned.
-func (c *Codec) decodeRequest(data []byte) (Message, error) {
-	var r Request
-	if err := json.Unmarshal(data, &r); err != nil {
-		return nil, err
+func (c *Codec) decodeRequest(command string, seq int, data []byte) (Message, error) {
+	ctor, ok := requestCtor[command]
+	if !ok {
+		return nil, &DecodeProtocolMessageFieldError{seq, "Request", "command", command}
 	}
-	if ctor, ok := c.requestCtor[r.Command]; ok {
-		requestPtr := ctor()
-		err := json.Unmarshal(data, requestPtr)
-		return requestPtr, err
-	}
-	return nil, &DecodeProtocolMessageFieldError{r.GetSeq(), "Request", "command", r.Command}
+	requestPtr := ctor()
+	err := json.Unmarshal(data, requestPtr)
+	return requestPtr, err
 }
 
 // decodeResponse determines what response type in the ProtocolMessage hierarchy
 // data corresponds to and uses json.Unmarshal to populate the corresponding
 // struct to be returned.
-func (c *Codec) decodeResponse(data []byte) (Message, error) {
-	var r Response
-	if err := json.Unmarshal(data, &r); err != nil {
-		return nil, err
-	}
-	if !r.Success {
+func (c *Codec) decodeResponse(command string, seq int, success bool, data []byte) (Message, error) {
+	if !success {
 		var er ErrorResponse
 		err := json.Unmarshal(data, &er)
 		return &er, err
 	}
-	if ctor, ok := c.responseCtor[r.Command]; ok {
-		responsePtr := ctor()
-		err := json.Unmarshal(data, responsePtr)
-		return responsePtr, err
+	ctor, ok := responseCtor[command]
+	if !ok {
+		return nil, &DecodeProtocolMessageFieldError{seq, "Response", "command", command}
 	}
-	return nil, &DecodeProtocolMessageFieldError{r.GetSeq(), "Response", "command", r.Command}
+	responsePtr := ctor()
+	err := json.Unmarshal(data, responsePtr)
+	return responsePtr, err
 }
 
 // decodeEvent determines what event type in the ProtocolMessage hierarchy
 // data corresponds to and uses json.Unmarshal to populate the corresponding
 // struct to be returned.
-func (c *Codec) decodeEvent(data []byte) (Message, error) {
-	var e Event
-	if err := json.Unmarshal(data, &e); err != nil {
-		return nil, err
+func (c *Codec) decodeEvent(event string, seq int, data []byte) (Message, error) {
+	ctor, ok := eventCtor[event]
+	if !ok {
+		return nil, &DecodeProtocolMessageFieldError{seq, "Event", "event", event}
 	}
-	if ctor, ok := c.eventCtor[e.Event]; ok {
-		eventPtr := ctor()
-		err := json.Unmarshal(data, eventPtr)
-		return eventPtr, err
-	}
-	return nil, &DecodeProtocolMessageFieldError{e.GetSeq(), "Event", "event", e.Event}
+	eventPtr := ctor()
+	err := json.Unmarshal(data, eventPtr)
+	return eventPtr, err
 }
 
 // DecodeProtocolMessage parses the JSON-encoded ProtocolMessage and returns


### PR DESCRIPTION
So far, the message was parsed three times:
1) To determine if it is a request/response/event (->Type) 2) To determine the command (->Command/Event/Success) to determine the
   right ctor
3) A final pass with the right ctor

Steps 1+2 can be combined into a single step by using a union type of the fields that are required to determine the right ctor. This PR does exactly that. It combines steps 1+2 so that the message needs to be parsed only once to determine the ctor.
The final parsing step (3) with the right ctor can of course not be elided. So the number of parsing operations is reduced from 3 to 2. This is a big win, because JSON parsing is slow, especially for large messages.