### PR TITLE
go.mod: retract v0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/google/go-dap
 
 go 1.13
+
+retract v0.9.0


### PR DESCRIPTION
A tagged version was released with some incorrect types. Retract that version.

For #82