### PR TITLE
Move interface method to embedded type

### DIFF
--- a/cmd/gentypes/gentypes.go
+++ b/cmd/gentypes/gentypes.go
@@ -428,16 +428,16 @@ func commentOutEachLine(s string) string {
 // emitMethodsForType may emit methods for typeName into sb.
 func emitMethodsForType(sb *strings.Builder, typeName string) {
 	if typeName == "ProtocolMessage" {
-		fmt.Fprintf(sb, "func (m *%s) GetSeq() int {return m.Seq}\n", typeName)
+		fmt.Fprintln(sb, "func (m *ProtocolMessage) GetSeq() int {return m.Seq}")
 	}
-	if strings.HasSuffix(typeName, "Request") && typeName != "Request" {
-		fmt.Fprintf(sb, "func (r *%s) GetRequest() *Request {return &r.Request}\n", typeName)
+	if typeName == "Request" {
+		fmt.Fprintln(sb, "func (r *Request) GetRequest() *Request {return r}")
 	}
-	if strings.HasSuffix(typeName, "Response") && typeName != "Response" {
-		fmt.Fprintf(sb, "func (r *%s) GetResponse() *Response {return &r.Response}\n", typeName)
+	if typeName == "Response" {
+		fmt.Fprintln(sb, "func (r *Response) GetResponse() *Response {return r}")
 	}
-	if strings.HasSuffix(typeName, "Event") && typeName != "Event" {
-		fmt.Fprintf(sb, "func (e *%s) GetEvent() *Event {return &e.Event}\n", typeName)
+	if typeName == "Event" {
+		fmt.Fprintln(sb, "func (e *Event) GetEvent() *Event {return e}")
 	}
 	if typeName == "LaunchRequest" || typeName == "AttachRequest" {
 		fmt.Fprintf(sb, "func (r *%s) GetArguments() json.RawMessage { return r.Arguments }\n", typeName)

--- a/schematypes.go
+++ b/schematypes.go
@@ -76,12 +76,16 @@ type Request struct {
 	Command string `json:"command"`
 }
 
+func (r *Request) GetRequest() *Request { return r }
+
 // Event: A debug adapter initiated event.
 type Event struct {
 	ProtocolMessage
 
 	Event string `json:"event"`
 }
+
+func (e *Event) GetEvent() *Event { return e }
 
 // Response: Response for a request.
 type Response struct {
@@ -93,6 +97,8 @@ type Response struct {
 	Message    string `json:"message,omitempty"`
 }
 
+func (r *Response) GetResponse() *Response { return r }
+
 // ErrorResponse: On error (whenever `success` is false), the body can provide more details.
 type ErrorResponse struct {
 	Response
@@ -103,8 +109,6 @@ type ErrorResponse struct {
 type ErrorResponseBody struct {
 	Error *ErrorMessage `json:"error,omitempty"`
 }
-
-func (r *ErrorResponse) GetResponse() *Response { return &r.Response }
 
 // CancelRequest: The `cancel` request is used by the client in two situations:
 // - to indicate that it is no longer interested in the result produced by a specific request issued earlier
@@ -122,8 +126,6 @@ type CancelRequest struct {
 	Arguments *CancelArguments `json:"arguments,omitempty"`
 }
 
-func (r *CancelRequest) GetRequest() *Request { return &r.Request }
-
 // CancelArguments: Arguments for `cancel` request.
 type CancelArguments struct {
 	RequestId  int    `json:"requestId,omitempty"`
@@ -134,8 +136,6 @@ type CancelArguments struct {
 type CancelResponse struct {
 	Response
 }
-
-func (r *CancelResponse) GetResponse() *Response { return &r.Response }
 
 // InitializedEvent: This event indicates that the debug adapter is ready to accept configuration requests (e.g. `setBreakpoints`, `setExceptionBreakpoints`).
 // A debug adapter is expected to send this event when it is ready to accept configuration requests (but not before the `initialize` request has finished).
@@ -149,8 +149,6 @@ func (r *CancelResponse) GetResponse() *Response { return &r.Response }
 type InitializedEvent struct {
 	Event
 }
-
-func (e *InitializedEvent) GetEvent() *Event { return &e.Event }
 
 // StoppedEvent: The event indicates that the execution of the debuggee has stopped due to some condition.
 // This can be caused by a breakpoint previously set, a stepping request has completed, by executing a debugger statement etc.
@@ -170,8 +168,6 @@ type StoppedEventBody struct {
 	HitBreakpointIds  []int  `json:"hitBreakpointIds,omitempty"`
 }
 
-func (e *StoppedEvent) GetEvent() *Event { return &e.Event }
-
 // ContinuedEvent: The event indicates that the execution of the debuggee has continued.
 // Please note: a debug adapter is not expected to send this event in response to a request that implies that execution continues, e.g. `launch` or `continue`.
 // It is only necessary to send a `continued` event if there was no previous request that implied this.
@@ -186,8 +182,6 @@ type ContinuedEventBody struct {
 	AllThreadsContinued bool `json:"allThreadsContinued,omitempty"`
 }
 
-func (e *ContinuedEvent) GetEvent() *Event { return &e.Event }
-
 // ExitedEvent: The event indicates that the debuggee has exited and returns its exit code.
 type ExitedEvent struct {
 	Event
@@ -198,8 +192,6 @@ type ExitedEvent struct {
 type ExitedEventBody struct {
 	ExitCode int `json:"exitCode"`
 }
-
-func (e *ExitedEvent) GetEvent() *Event { return &e.Event }
 
 // TerminatedEvent: The event indicates that debugging of the debuggee has terminated. This does **not** mean that the debuggee itself has exited.
 type TerminatedEvent struct {
@@ -212,8 +204,6 @@ type TerminatedEventBody struct {
 	Restart interface{} `json:"restart,omitempty"`
 }
 
-func (e *TerminatedEvent) GetEvent() *Event { return &e.Event }
-
 // ThreadEvent: The event indicates that a thread has started or exited.
 type ThreadEvent struct {
 	Event
@@ -225,8 +215,6 @@ type ThreadEventBody struct {
 	Reason   string `json:"reason"`
 	ThreadId int    `json:"threadId"`
 }
-
-func (e *ThreadEvent) GetEvent() *Event { return &e.Event }
 
 // OutputEvent: The event indicates that the target has produced some output.
 type OutputEvent struct {
@@ -246,8 +234,6 @@ type OutputEventBody struct {
 	Data               interface{} `json:"data,omitempty"`
 }
 
-func (e *OutputEvent) GetEvent() *Event { return &e.Event }
-
 // BreakpointEvent: The event indicates that some information about a breakpoint has changed.
 type BreakpointEvent struct {
 	Event
@@ -259,8 +245,6 @@ type BreakpointEventBody struct {
 	Reason     string     `json:"reason"`
 	Breakpoint Breakpoint `json:"breakpoint"`
 }
-
-func (e *BreakpointEvent) GetEvent() *Event { return &e.Event }
 
 // ModuleEvent: The event indicates that some information about a module has changed.
 type ModuleEvent struct {
@@ -274,8 +258,6 @@ type ModuleEventBody struct {
 	Module Module `json:"module"`
 }
 
-func (e *ModuleEvent) GetEvent() *Event { return &e.Event }
-
 // LoadedSourceEvent: The event indicates that some source has been added, changed, or removed from the set of all loaded sources.
 type LoadedSourceEvent struct {
 	Event
@@ -287,8 +269,6 @@ type LoadedSourceEventBody struct {
 	Reason string `json:"reason"`
 	Source Source `json:"source"`
 }
-
-func (e *LoadedSourceEvent) GetEvent() *Event { return &e.Event }
 
 // ProcessEvent: The event indicates that the debugger has begun debugging a new process. Either one that it has launched, or one that it has attached to.
 type ProcessEvent struct {
@@ -305,8 +285,6 @@ type ProcessEventBody struct {
 	PointerSize     int    `json:"pointerSize,omitempty"`
 }
 
-func (e *ProcessEvent) GetEvent() *Event { return &e.Event }
-
 // CapabilitiesEvent: The event indicates that one or more capabilities have changed.
 // Since the capabilities are dependent on the client and its UI, it might not be possible to change that at random times (or too late).
 // Consequently this event has a hint characteristic: a client can only be expected to make a 'best effort' in honoring individual capabilities but there are no guarantees.
@@ -320,8 +298,6 @@ type CapabilitiesEvent struct {
 type CapabilitiesEventBody struct {
 	Capabilities Capabilities `json:"capabilities"`
 }
-
-func (e *CapabilitiesEvent) GetEvent() *Event { return &e.Event }
 
 // ProgressStartEvent: The event signals that a long running operation is about to start and provides additional information for the client to set up a corresponding progress and cancellation UI.
 // The client is free to delay the showing of the UI in order to reduce flicker.
@@ -341,8 +317,6 @@ type ProgressStartEventBody struct {
 	Percentage  int    `json:"percentage,omitempty"`
 }
 
-func (e *ProgressStartEvent) GetEvent() *Event { return &e.Event }
-
 // ProgressUpdateEvent: The event signals that the progress reporting needs to be updated with a new message and/or percentage.
 // The client does not have to update the UI immediately, but the clients needs to keep track of the message and/or percentage values.
 // This event should only be sent if the corresponding capability `supportsProgressReporting` is true.
@@ -358,8 +332,6 @@ type ProgressUpdateEventBody struct {
 	Percentage int    `json:"percentage,omitempty"`
 }
 
-func (e *ProgressUpdateEvent) GetEvent() *Event { return &e.Event }
-
 // ProgressEndEvent: The event signals the end of the progress reporting with a final message.
 // This event should only be sent if the corresponding capability `supportsProgressReporting` is true.
 type ProgressEndEvent struct {
@@ -372,8 +344,6 @@ type ProgressEndEventBody struct {
 	ProgressId string `json:"progressId"`
 	Message    string `json:"message,omitempty"`
 }
-
-func (e *ProgressEndEvent) GetEvent() *Event { return &e.Event }
 
 // InvalidatedEvent: This event signals that some state in the debug adapter has changed and requires that the client needs to re-render the data snapshot previously requested.
 // Debug adapters do not have to emit this event for runtime changes like stopped or thread events because in that case the client refetches the new state anyway. But the event can be used for example to refresh the UI after rendering formatting has changed in the debug adapter.
@@ -390,8 +360,6 @@ type InvalidatedEventBody struct {
 	StackFrameId int                `json:"stackFrameId,omitempty"`
 }
 
-func (e *InvalidatedEvent) GetEvent() *Event { return &e.Event }
-
 // MemoryEvent: This event indicates that some memory range has been updated. It should only be sent if the corresponding capability `supportsMemoryEvent` is true.
 // Clients typically react to the event by re-issuing a `readMemory` request if they show the memory identified by the `memoryReference` and if the updated memory range overlaps the displayed range. Clients should not make assumptions how individual memory references relate to each other, so they should not assume that they are part of a single continuous address range and might overlap.
 // Debug adapters can use this event to indicate that the contents of a memory range has changed due to some other request like `setVariable` or `setExpression`. Debug adapters are not expected to emit this event for each and every memory change of a running program, because that information is typically not available from debuggers and it would flood clients with too many events.
@@ -407,8 +375,6 @@ type MemoryEventBody struct {
 	Count           int    `json:"count"`
 }
 
-func (e *MemoryEvent) GetEvent() *Event { return &e.Event }
-
 // RunInTerminalRequest: This request is sent from the debug adapter to the client to run a command in a terminal.
 // This is typically used to launch the debuggee in a terminal provided by the client.
 // This request should only be called if the corresponding client capability `supportsRunInTerminalRequest` is true.
@@ -419,8 +385,6 @@ type RunInTerminalRequest struct {
 
 	Arguments RunInTerminalRequestArguments `json:"arguments"`
 }
-
-func (r *RunInTerminalRequest) GetRequest() *Request { return &r.Request }
 
 // RunInTerminalRequestArguments: Arguments for `runInTerminal` request.
 type RunInTerminalRequestArguments struct {
@@ -444,8 +408,6 @@ type RunInTerminalResponseBody struct {
 	ShellProcessId int `json:"shellProcessId,omitempty"`
 }
 
-func (r *RunInTerminalResponse) GetResponse() *Response { return &r.Response }
-
 // StartDebuggingRequest: This request is sent from the debug adapter to the client to start a new debug session of the same type as the caller.
 // This request should only be sent if the corresponding client capability `supportsStartDebuggingRequest` is true.
 // A client implementation of `startDebugging` should start a new debug session (of the same type as the caller) in the same way that the caller's session was started. If the client supports hierarchical debug sessions, the newly created session can be treated as a child of the caller session.
@@ -454,8 +416,6 @@ type StartDebuggingRequest struct {
 
 	Arguments StartDebuggingRequestArguments `json:"arguments"`
 }
-
-func (r *StartDebuggingRequest) GetRequest() *Request { return &r.Request }
 
 // StartDebuggingRequestArguments: Arguments for `startDebugging` request.
 type StartDebuggingRequestArguments struct {
@@ -468,8 +428,6 @@ type StartDebuggingResponse struct {
 	Response
 }
 
-func (r *StartDebuggingResponse) GetResponse() *Response { return &r.Response }
-
 // InitializeRequest: The `initialize` request is sent as the first request from the client to the debug adapter in order to configure it with client capabilities and to retrieve capabilities from the debug adapter.
 // Until the debug adapter has responded with an `initialize` response, the client must not send any additional requests or events to the debug adapter.
 // In addition the debug adapter is not allowed to send any requests or events to the client until it has responded with an `initialize` response.
@@ -479,8 +437,6 @@ type InitializeRequest struct {
 
 	Arguments InitializeRequestArguments `json:"arguments"`
 }
-
-func (r *InitializeRequest) GetRequest() *Request { return &r.Request }
 
 // InitializeRequestArguments: Arguments for `initialize` request.
 type InitializeRequestArguments struct {
@@ -509,8 +465,6 @@ type InitializeResponse struct {
 	Body Capabilities `json:"body,omitempty"`
 }
 
-func (r *InitializeResponse) GetResponse() *Response { return &r.Response }
-
 // ConfigurationDoneRequest: This request indicates that the client has finished initialization of the debug adapter.
 // So it is the last request in the sequence of configuration requests (which was started by the `initialized` event).
 // Clients should only call this request if the corresponding capability `supportsConfigurationDoneRequest` is true.
@@ -519,8 +473,6 @@ type ConfigurationDoneRequest struct {
 
 	Arguments *ConfigurationDoneArguments `json:"arguments,omitempty"`
 }
-
-func (r *ConfigurationDoneRequest) GetRequest() *Request { return &r.Request }
 
 // ConfigurationDoneArguments: Arguments for `configurationDone` request.
 type ConfigurationDoneArguments struct {
@@ -531,8 +483,6 @@ type ConfigurationDoneResponse struct {
 	Response
 }
 
-func (r *ConfigurationDoneResponse) GetResponse() *Response { return &r.Response }
-
 // LaunchRequest: This launch request is sent from the client to the debug adapter to start the debuggee with or without debugging (if `noDebug` is true).
 // Since launching is debugger/runtime specific, the arguments for this request are not part of this specification.
 type LaunchRequest struct {
@@ -541,15 +491,12 @@ type LaunchRequest struct {
 	Arguments json.RawMessage `json:"arguments"`
 }
 
-func (r *LaunchRequest) GetRequest() *Request          { return &r.Request }
 func (r *LaunchRequest) GetArguments() json.RawMessage { return r.Arguments }
 
 // LaunchResponse: Response to `launch` request. This is just an acknowledgement, so no body field is required.
 type LaunchResponse struct {
 	Response
 }
-
-func (r *LaunchResponse) GetResponse() *Response { return &r.Response }
 
 // AttachRequest: The `attach` request is sent from the client to the debug adapter to attach to a debuggee that is already running.
 // Since attaching is debugger/runtime specific, the arguments for this request are not part of this specification.
@@ -559,15 +506,12 @@ type AttachRequest struct {
 	Arguments json.RawMessage `json:"arguments"`
 }
 
-func (r *AttachRequest) GetRequest() *Request          { return &r.Request }
 func (r *AttachRequest) GetArguments() json.RawMessage { return r.Arguments }
 
 // AttachResponse: Response to `attach` request. This is just an acknowledgement, so no body field is required.
 type AttachResponse struct {
 	Response
 }
-
-func (r *AttachResponse) GetResponse() *Response { return &r.Response }
 
 // RestartRequest: Restarts a debug session. Clients should only call this request if the corresponding capability `supportsRestartRequest` is true.
 // If the capability is missing or has the value false, a typical client emulates `restart` by terminating the debug adapter first and then launching it anew.
@@ -576,8 +520,6 @@ type RestartRequest struct {
 
 	Arguments *RestartArguments `json:"arguments,omitempty"`
 }
-
-func (r *RestartRequest) GetRequest() *Request { return &r.Request }
 
 // RestartArguments: Arguments for `restart` request.
 type RestartArguments struct {
@@ -589,8 +531,6 @@ type RestartResponse struct {
 	Response
 }
 
-func (r *RestartResponse) GetResponse() *Response { return &r.Response }
-
 // DisconnectRequest: The `disconnect` request asks the debug adapter to disconnect from the debuggee (thus ending the debug session) and then to shut down itself (the debug adapter).
 // In addition, the debug adapter must terminate the debuggee if it was started with the `launch` request. If an `attach` request was used to connect to the debuggee, then the debug adapter must not terminate the debuggee.
 // This implicit behavior of when to terminate the debuggee can be overridden with the `terminateDebuggee` argument (which is only supported by a debug adapter if the corresponding capability `supportTerminateDebuggee` is true).
@@ -599,8 +539,6 @@ type DisconnectRequest struct {
 
 	Arguments *DisconnectArguments `json:"arguments,omitempty"`
 }
-
-func (r *DisconnectRequest) GetRequest() *Request { return &r.Request }
 
 // DisconnectArguments: Arguments for `disconnect` request.
 type DisconnectArguments struct {
@@ -614,8 +552,6 @@ type DisconnectResponse struct {
 	Response
 }
 
-func (r *DisconnectResponse) GetResponse() *Response { return &r.Response }
-
 // TerminateRequest: The `terminate` request is sent from the client to the debug adapter in order to shut down the debuggee gracefully. Clients should only call this request if the capability `supportsTerminateRequest` is true.
 // Typically a debug adapter implements `terminate` by sending a software signal which the debuggee intercepts in order to clean things up properly before terminating itself.
 // Please note that this request does not directly affect the state of the debug session: if the debuggee decides to veto the graceful shutdown for any reason by not terminating itself, then the debug session just continues.
@@ -625,8 +561,6 @@ type TerminateRequest struct {
 
 	Arguments *TerminateArguments `json:"arguments,omitempty"`
 }
-
-func (r *TerminateRequest) GetRequest() *Request { return &r.Request }
 
 // TerminateArguments: Arguments for `terminate` request.
 type TerminateArguments struct {
@@ -638,8 +572,6 @@ type TerminateResponse struct {
 	Response
 }
 
-func (r *TerminateResponse) GetResponse() *Response { return &r.Response }
-
 // BreakpointLocationsRequest: The `breakpointLocations` request returns all possible locations for source breakpoints in a given range.
 // Clients should only call this request if the corresponding capability `supportsBreakpointLocationsRequest` is true.
 type BreakpointLocationsRequest struct {
@@ -647,8 +579,6 @@ type BreakpointLocationsRequest struct {
 
 	Arguments *BreakpointLocationsArguments `json:"arguments,omitempty"`
 }
-
-func (r *BreakpointLocationsRequest) GetRequest() *Request { return &r.Request }
 
 // BreakpointLocationsArguments: Arguments for `breakpointLocations` request.
 type BreakpointLocationsArguments struct {
@@ -671,8 +601,6 @@ type BreakpointLocationsResponseBody struct {
 	Breakpoints []BreakpointLocation `json:"breakpoints"`
 }
 
-func (r *BreakpointLocationsResponse) GetResponse() *Response { return &r.Response }
-
 // SetBreakpointsRequest: Sets multiple breakpoints for a single source and clears all previous breakpoints in that source.
 // To clear all breakpoint for a source, specify an empty array.
 // When a breakpoint is hit, a `stopped` event (with reason `breakpoint`) is generated.
@@ -681,8 +609,6 @@ type SetBreakpointsRequest struct {
 
 	Arguments SetBreakpointsArguments `json:"arguments"`
 }
-
-func (r *SetBreakpointsRequest) GetRequest() *Request { return &r.Request }
 
 // SetBreakpointsArguments: Arguments for `setBreakpoints` request.
 type SetBreakpointsArguments struct {
@@ -707,8 +633,6 @@ type SetBreakpointsResponseBody struct {
 	Breakpoints []Breakpoint `json:"breakpoints"`
 }
 
-func (r *SetBreakpointsResponse) GetResponse() *Response { return &r.Response }
-
 // SetFunctionBreakpointsRequest: Replaces all existing function breakpoints with new function breakpoints.
 // To clear all function breakpoints, specify an empty array.
 // When a function breakpoint is hit, a `stopped` event (with reason `function breakpoint`) is generated.
@@ -718,8 +642,6 @@ type SetFunctionBreakpointsRequest struct {
 
 	Arguments SetFunctionBreakpointsArguments `json:"arguments"`
 }
-
-func (r *SetFunctionBreakpointsRequest) GetRequest() *Request { return &r.Request }
 
 // SetFunctionBreakpointsArguments: Arguments for `setFunctionBreakpoints` request.
 type SetFunctionBreakpointsArguments struct {
@@ -738,8 +660,6 @@ type SetFunctionBreakpointsResponseBody struct {
 	Breakpoints []Breakpoint `json:"breakpoints"`
 }
 
-func (r *SetFunctionBreakpointsResponse) GetResponse() *Response { return &r.Response }
-
 // SetExceptionBreakpointsRequest: The request configures the debugger's response to thrown exceptions.
 // If an exception is configured to break, a `stopped` event is fired (with reason `exception`).
 // Clients should only call this request if the corresponding capability `exceptionBreakpointFilters` returns one or more filters.
@@ -748,8 +668,6 @@ type SetExceptionBreakpointsRequest struct {
 
 	Arguments SetExceptionBreakpointsArguments `json:"arguments"`
 }
-
-func (r *SetExceptionBreakpointsRequest) GetRequest() *Request { return &r.Request }
 
 // SetExceptionBreakpointsArguments: Arguments for `setExceptionBreakpoints` request.
 type SetExceptionBreakpointsArguments struct {
@@ -772,8 +690,6 @@ type SetExceptionBreakpointsResponseBody struct {
 	Breakpoints []Breakpoint `json:"breakpoints,omitempty"`
 }
 
-func (r *SetExceptionBreakpointsResponse) GetResponse() *Response { return &r.Response }
-
 // DataBreakpointInfoRequest: Obtains information on a possible data breakpoint that could be set on an expression or variable.
 // Clients should only call this request if the corresponding capability `supportsDataBreakpoints` is true.
 type DataBreakpointInfoRequest struct {
@@ -781,8 +697,6 @@ type DataBreakpointInfoRequest struct {
 
 	Arguments DataBreakpointInfoArguments `json:"arguments"`
 }
-
-func (r *DataBreakpointInfoRequest) GetRequest() *Request { return &r.Request }
 
 // DataBreakpointInfoArguments: Arguments for `dataBreakpointInfo` request.
 type DataBreakpointInfoArguments struct {
@@ -805,8 +719,6 @@ type DataBreakpointInfoResponseBody struct {
 	CanPersist  bool                       `json:"canPersist,omitempty"`
 }
 
-func (r *DataBreakpointInfoResponse) GetResponse() *Response { return &r.Response }
-
 // SetDataBreakpointsRequest: Replaces all existing data breakpoints with new data breakpoints.
 // To clear all data breakpoints, specify an empty array.
 // When a data breakpoint is hit, a `stopped` event (with reason `data breakpoint`) is generated.
@@ -816,8 +728,6 @@ type SetDataBreakpointsRequest struct {
 
 	Arguments SetDataBreakpointsArguments `json:"arguments"`
 }
-
-func (r *SetDataBreakpointsRequest) GetRequest() *Request { return &r.Request }
 
 // SetDataBreakpointsArguments: Arguments for `setDataBreakpoints` request.
 type SetDataBreakpointsArguments struct {
@@ -836,8 +746,6 @@ type SetDataBreakpointsResponseBody struct {
 	Breakpoints []Breakpoint `json:"breakpoints"`
 }
 
-func (r *SetDataBreakpointsResponse) GetResponse() *Response { return &r.Response }
-
 // SetInstructionBreakpointsRequest: Replaces all existing instruction breakpoints. Typically, instruction breakpoints would be set from a disassembly window.
 // To clear all instruction breakpoints, specify an empty array.
 // When an instruction breakpoint is hit, a `stopped` event (with reason `instruction breakpoint`) is generated.
@@ -847,8 +755,6 @@ type SetInstructionBreakpointsRequest struct {
 
 	Arguments SetInstructionBreakpointsArguments `json:"arguments"`
 }
-
-func (r *SetInstructionBreakpointsRequest) GetRequest() *Request { return &r.Request }
 
 // SetInstructionBreakpointsArguments: Arguments for `setInstructionBreakpoints` request
 type SetInstructionBreakpointsArguments struct {
@@ -866,16 +772,12 @@ type SetInstructionBreakpointsResponseBody struct {
 	Breakpoints []Breakpoint `json:"breakpoints"`
 }
 
-func (r *SetInstructionBreakpointsResponse) GetResponse() *Response { return &r.Response }
-
 // ContinueRequest: The request resumes execution of all threads. If the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true resumes only the specified thread. If not all threads were resumed, the `allThreadsContinued` attribute of the response should be set to false.
 type ContinueRequest struct {
 	Request
 
 	Arguments ContinueArguments `json:"arguments"`
 }
-
-func (r *ContinueRequest) GetRequest() *Request { return &r.Request }
 
 // ContinueArguments: Arguments for `continue` request.
 type ContinueArguments struct {
@@ -894,8 +796,6 @@ type ContinueResponseBody struct {
 	AllThreadsContinued bool `json:"allThreadsContinued"`
 }
 
-func (r *ContinueResponse) GetResponse() *Response { return &r.Response }
-
 // NextRequest: The request executes one step (in the given granularity) for the specified thread and allows all other threads to run freely by resuming them.
 // If the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true prevents other suspended threads from resuming.
 // The debug adapter first sends the response and then a `stopped` event (with reason `step`) after the step has completed.
@@ -904,8 +804,6 @@ type NextRequest struct {
 
 	Arguments NextArguments `json:"arguments"`
 }
-
-func (r *NextRequest) GetRequest() *Request { return &r.Request }
 
 // NextArguments: Arguments for `next` request.
 type NextArguments struct {
@@ -918,8 +816,6 @@ type NextArguments struct {
 type NextResponse struct {
 	Response
 }
-
-func (r *NextResponse) GetResponse() *Response { return &r.Response }
 
 // StepInRequest: The request resumes the given thread to step into a function/method and allows all other threads to run freely by resuming them.
 // If the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true prevents other suspended threads from resuming.
@@ -934,8 +830,6 @@ type StepInRequest struct {
 	Arguments StepInArguments `json:"arguments"`
 }
 
-func (r *StepInRequest) GetRequest() *Request { return &r.Request }
-
 // StepInArguments: Arguments for `stepIn` request.
 type StepInArguments struct {
 	ThreadId     int                 `json:"threadId"`
@@ -949,8 +843,6 @@ type StepInResponse struct {
 	Response
 }
 
-func (r *StepInResponse) GetResponse() *Response { return &r.Response }
-
 // StepOutRequest: The request resumes the given thread to step out (return) from a function/method and allows all other threads to run freely by resuming them.
 // If the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true prevents other suspended threads from resuming.
 // The debug adapter first sends the response and then a `stopped` event (with reason `step`) after the step has completed.
@@ -959,8 +851,6 @@ type StepOutRequest struct {
 
 	Arguments StepOutArguments `json:"arguments"`
 }
-
-func (r *StepOutRequest) GetRequest() *Request { return &r.Request }
 
 // StepOutArguments: Arguments for `stepOut` request.
 type StepOutArguments struct {
@@ -974,8 +864,6 @@ type StepOutResponse struct {
 	Response
 }
 
-func (r *StepOutResponse) GetResponse() *Response { return &r.Response }
-
 // StepBackRequest: The request executes one backward step (in the given granularity) for the specified thread and allows all other threads to run backward freely by resuming them.
 // If the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true prevents other suspended threads from resuming.
 // The debug adapter first sends the response and then a `stopped` event (with reason `step`) after the step has completed.
@@ -985,8 +873,6 @@ type StepBackRequest struct {
 
 	Arguments StepBackArguments `json:"arguments"`
 }
-
-func (r *StepBackRequest) GetRequest() *Request { return &r.Request }
 
 // StepBackArguments: Arguments for `stepBack` request.
 type StepBackArguments struct {
@@ -1000,8 +886,6 @@ type StepBackResponse struct {
 	Response
 }
 
-func (r *StepBackResponse) GetResponse() *Response { return &r.Response }
-
 // ReverseContinueRequest: The request resumes backward execution of all threads. If the debug adapter supports single thread execution (see capability `supportsSingleThreadExecutionRequests`), setting the `singleThread` argument to true resumes only the specified thread. If not all threads were resumed, the `allThreadsContinued` attribute of the response should be set to false.
 // Clients should only call this request if the corresponding capability `supportsStepBack` is true.
 type ReverseContinueRequest struct {
@@ -1009,8 +893,6 @@ type ReverseContinueRequest struct {
 
 	Arguments ReverseContinueArguments `json:"arguments"`
 }
-
-func (r *ReverseContinueRequest) GetRequest() *Request { return &r.Request }
 
 // ReverseContinueArguments: Arguments for `reverseContinue` request.
 type ReverseContinueArguments struct {
@@ -1023,8 +905,6 @@ type ReverseContinueResponse struct {
 	Response
 }
 
-func (r *ReverseContinueResponse) GetResponse() *Response { return &r.Response }
-
 // RestartFrameRequest: The request restarts execution of the specified stack frame.
 // The debug adapter first sends the response and then a `stopped` event (with reason `restart`) after the restart has completed.
 // Clients should only call this request if the corresponding capability `supportsRestartFrame` is true.
@@ -1033,8 +913,6 @@ type RestartFrameRequest struct {
 
 	Arguments RestartFrameArguments `json:"arguments"`
 }
-
-func (r *RestartFrameRequest) GetRequest() *Request { return &r.Request }
 
 // RestartFrameArguments: Arguments for `restartFrame` request.
 type RestartFrameArguments struct {
@@ -1045,8 +923,6 @@ type RestartFrameArguments struct {
 type RestartFrameResponse struct {
 	Response
 }
-
-func (r *RestartFrameResponse) GetResponse() *Response { return &r.Response }
 
 // GotoRequest: The request sets the location where the debuggee will continue to run.
 // This makes it possible to skip the execution of code or to execute code again.
@@ -1059,8 +935,6 @@ type GotoRequest struct {
 	Arguments GotoArguments `json:"arguments"`
 }
 
-func (r *GotoRequest) GetRequest() *Request { return &r.Request }
-
 // GotoArguments: Arguments for `goto` request.
 type GotoArguments struct {
 	ThreadId int `json:"threadId"`
@@ -1072,8 +946,6 @@ type GotoResponse struct {
 	Response
 }
 
-func (r *GotoResponse) GetResponse() *Response { return &r.Response }
-
 // PauseRequest: The request suspends the debuggee.
 // The debug adapter first sends the response and then a `stopped` event (with reason `pause`) after the thread has been paused successfully.
 type PauseRequest struct {
@@ -1081,8 +953,6 @@ type PauseRequest struct {
 
 	Arguments PauseArguments `json:"arguments"`
 }
-
-func (r *PauseRequest) GetRequest() *Request { return &r.Request }
 
 // PauseArguments: Arguments for `pause` request.
 type PauseArguments struct {
@@ -1094,8 +964,6 @@ type PauseResponse struct {
 	Response
 }
 
-func (r *PauseResponse) GetResponse() *Response { return &r.Response }
-
 // StackTraceRequest: The request returns a stacktrace from the current execution state of a given thread.
 // A client can request all stack frames by omitting the startFrame and levels arguments. For performance-conscious clients and if the corresponding capability `supportsDelayedStackTraceLoading` is true, stack frames can be retrieved in a piecemeal way with the `startFrame` and `levels` arguments. The response of the `stackTrace` request may contain a `totalFrames` property that hints at the total number of frames in the stack. If a client needs this total number upfront, it can issue a request for a single (first) frame and depending on the value of `totalFrames` decide how to proceed. In any case a client should be prepared to receive fewer frames than requested, which is an indication that the end of the stack has been reached.
 type StackTraceRequest struct {
@@ -1103,8 +971,6 @@ type StackTraceRequest struct {
 
 	Arguments StackTraceArguments `json:"arguments"`
 }
-
-func (r *StackTraceRequest) GetRequest() *Request { return &r.Request }
 
 // StackTraceArguments: Arguments for `stackTrace` request.
 type StackTraceArguments struct {
@@ -1126,16 +992,12 @@ type StackTraceResponseBody struct {
 	TotalFrames int          `json:"totalFrames,omitempty"`
 }
 
-func (r *StackTraceResponse) GetResponse() *Response { return &r.Response }
-
 // ScopesRequest: The request returns the variable scopes for a given stack frame ID.
 type ScopesRequest struct {
 	Request
 
 	Arguments ScopesArguments `json:"arguments"`
 }
-
-func (r *ScopesRequest) GetRequest() *Request { return &r.Request }
 
 // ScopesArguments: Arguments for `scopes` request.
 type ScopesArguments struct {
@@ -1153,8 +1015,6 @@ type ScopesResponseBody struct {
 	Scopes []Scope `json:"scopes"`
 }
 
-func (r *ScopesResponse) GetResponse() *Response { return &r.Response }
-
 // VariablesRequest: Retrieves all child variables for the given variable reference.
 // A filter can be used to limit the fetched children to either named or indexed children.
 type VariablesRequest struct {
@@ -1162,8 +1022,6 @@ type VariablesRequest struct {
 
 	Arguments VariablesArguments `json:"arguments"`
 }
-
-func (r *VariablesRequest) GetRequest() *Request { return &r.Request }
 
 // VariablesArguments: Arguments for `variables` request.
 type VariablesArguments struct {
@@ -1185,8 +1043,6 @@ type VariablesResponseBody struct {
 	Variables []Variable `json:"variables"`
 }
 
-func (r *VariablesResponse) GetResponse() *Response { return &r.Response }
-
 // SetVariableRequest: Set the variable with the given name in the variable container to a new value. Clients should only call this request if the corresponding capability `supportsSetVariable` is true.
 // If a debug adapter implements both `setVariable` and `setExpression`, a client will only use `setExpression` if the variable has an `evaluateName` property.
 type SetVariableRequest struct {
@@ -1194,8 +1050,6 @@ type SetVariableRequest struct {
 
 	Arguments SetVariableArguments `json:"arguments"`
 }
-
-func (r *SetVariableRequest) GetRequest() *Request { return &r.Request }
 
 // SetVariableArguments: Arguments for `setVariable` request.
 type SetVariableArguments struct {
@@ -1220,16 +1074,12 @@ type SetVariableResponseBody struct {
 	IndexedVariables   int    `json:"indexedVariables,omitempty"`
 }
 
-func (r *SetVariableResponse) GetResponse() *Response { return &r.Response }
-
 // SourceRequest: The request retrieves the source code for a given source reference.
 type SourceRequest struct {
 	Request
 
 	Arguments SourceArguments `json:"arguments"`
 }
-
-func (r *SourceRequest) GetRequest() *Request { return &r.Request }
 
 // SourceArguments: Arguments for `source` request.
 type SourceArguments struct {
@@ -1249,14 +1099,10 @@ type SourceResponseBody struct {
 	MimeType string `json:"mimeType,omitempty"`
 }
 
-func (r *SourceResponse) GetResponse() *Response { return &r.Response }
-
 // ThreadsRequest: The request retrieves a list of all threads.
 type ThreadsRequest struct {
 	Request
 }
-
-func (r *ThreadsRequest) GetRequest() *Request { return &r.Request }
 
 // ThreadsResponse: Response to `threads` request.
 type ThreadsResponse struct {
@@ -1269,8 +1115,6 @@ type ThreadsResponseBody struct {
 	Threads []Thread `json:"threads"`
 }
 
-func (r *ThreadsResponse) GetResponse() *Response { return &r.Response }
-
 // TerminateThreadsRequest: The request terminates the threads with the given ids.
 // Clients should only call this request if the corresponding capability `supportsTerminateThreadsRequest` is true.
 type TerminateThreadsRequest struct {
@@ -1278,8 +1122,6 @@ type TerminateThreadsRequest struct {
 
 	Arguments TerminateThreadsArguments `json:"arguments"`
 }
-
-func (r *TerminateThreadsRequest) GetRequest() *Request { return &r.Request }
 
 // TerminateThreadsArguments: Arguments for `terminateThreads` request.
 type TerminateThreadsArguments struct {
@@ -1291,8 +1133,6 @@ type TerminateThreadsResponse struct {
 	Response
 }
 
-func (r *TerminateThreadsResponse) GetResponse() *Response { return &r.Response }
-
 // ModulesRequest: Modules can be retrieved from the debug adapter with this request which can either return all modules or a range of modules to support paging.
 // Clients should only call this request if the corresponding capability `supportsModulesRequest` is true.
 type ModulesRequest struct {
@@ -1300,8 +1140,6 @@ type ModulesRequest struct {
 
 	Arguments ModulesArguments `json:"arguments"`
 }
-
-func (r *ModulesRequest) GetRequest() *Request { return &r.Request }
 
 // ModulesArguments: Arguments for `modules` request.
 type ModulesArguments struct {
@@ -1321,8 +1159,6 @@ type ModulesResponseBody struct {
 	TotalModules int      `json:"totalModules,omitempty"`
 }
 
-func (r *ModulesResponse) GetResponse() *Response { return &r.Response }
-
 // LoadedSourcesRequest: Retrieves the set of all sources currently loaded by the debugged process.
 // Clients should only call this request if the corresponding capability `supportsLoadedSourcesRequest` is true.
 type LoadedSourcesRequest struct {
@@ -1330,8 +1166,6 @@ type LoadedSourcesRequest struct {
 
 	Arguments *LoadedSourcesArguments `json:"arguments,omitempty"`
 }
-
-func (r *LoadedSourcesRequest) GetRequest() *Request { return &r.Request }
 
 // LoadedSourcesArguments: Arguments for `loadedSources` request.
 type LoadedSourcesArguments struct {
@@ -1348,8 +1182,6 @@ type LoadedSourcesResponseBody struct {
 	Sources []Source `json:"sources"`
 }
 
-func (r *LoadedSourcesResponse) GetResponse() *Response { return &r.Response }
-
 // EvaluateRequest: Evaluates the given expression in the context of the topmost stack frame.
 // The expression has access to any variables and arguments that are in scope.
 type EvaluateRequest struct {
@@ -1357,8 +1189,6 @@ type EvaluateRequest struct {
 
 	Arguments EvaluateArguments `json:"arguments"`
 }
-
-func (r *EvaluateRequest) GetRequest() *Request { return &r.Request }
 
 // EvaluateArguments: Arguments for `evaluate` request.
 type EvaluateArguments struct {
@@ -1385,8 +1215,6 @@ type EvaluateResponseBody struct {
 	MemoryReference    string                    `json:"memoryReference,omitempty"`
 }
 
-func (r *EvaluateResponse) GetResponse() *Response { return &r.Response }
-
 // SetExpressionRequest: Evaluates the given `value` expression and assigns it to the `expression` which must be a modifiable l-value.
 // The expressions have access to any variables and arguments that are in scope of the specified frame.
 // Clients should only call this request if the corresponding capability `supportsSetExpression` is true.
@@ -1396,8 +1224,6 @@ type SetExpressionRequest struct {
 
 	Arguments SetExpressionArguments `json:"arguments"`
 }
-
-func (r *SetExpressionRequest) GetRequest() *Request { return &r.Request }
 
 // SetExpressionArguments: Arguments for `setExpression` request.
 type SetExpressionArguments struct {
@@ -1423,8 +1249,6 @@ type SetExpressionResponseBody struct {
 	IndexedVariables   int                       `json:"indexedVariables,omitempty"`
 }
 
-func (r *SetExpressionResponse) GetResponse() *Response { return &r.Response }
-
 // StepInTargetsRequest: This request retrieves the possible step-in targets for the specified stack frame.
 // These targets can be used in the `stepIn` request.
 // Clients should only call this request if the corresponding capability `supportsStepInTargetsRequest` is true.
@@ -1433,8 +1257,6 @@ type StepInTargetsRequest struct {
 
 	Arguments StepInTargetsArguments `json:"arguments"`
 }
-
-func (r *StepInTargetsRequest) GetRequest() *Request { return &r.Request }
 
 // StepInTargetsArguments: Arguments for `stepInTargets` request.
 type StepInTargetsArguments struct {
@@ -1452,8 +1274,6 @@ type StepInTargetsResponseBody struct {
 	Targets []StepInTarget `json:"targets"`
 }
 
-func (r *StepInTargetsResponse) GetResponse() *Response { return &r.Response }
-
 // GotoTargetsRequest: This request retrieves the possible goto targets for the specified source location.
 // These targets can be used in the `goto` request.
 // Clients should only call this request if the corresponding capability `supportsGotoTargetsRequest` is true.
@@ -1462,8 +1282,6 @@ type GotoTargetsRequest struct {
 
 	Arguments GotoTargetsArguments `json:"arguments"`
 }
-
-func (r *GotoTargetsRequest) GetRequest() *Request { return &r.Request }
 
 // GotoTargetsArguments: Arguments for `gotoTargets` request.
 type GotoTargetsArguments struct {
@@ -1483,8 +1301,6 @@ type GotoTargetsResponseBody struct {
 	Targets []GotoTarget `json:"targets"`
 }
 
-func (r *GotoTargetsResponse) GetResponse() *Response { return &r.Response }
-
 // CompletionsRequest: Returns a list of possible completions for a given caret position and text.
 // Clients should only call this request if the corresponding capability `supportsCompletionsRequest` is true.
 type CompletionsRequest struct {
@@ -1492,8 +1308,6 @@ type CompletionsRequest struct {
 
 	Arguments CompletionsArguments `json:"arguments"`
 }
-
-func (r *CompletionsRequest) GetRequest() *Request { return &r.Request }
 
 // CompletionsArguments: Arguments for `completions` request.
 type CompletionsArguments struct {
@@ -1514,8 +1328,6 @@ type CompletionsResponseBody struct {
 	Targets []CompletionItem `json:"targets"`
 }
 
-func (r *CompletionsResponse) GetResponse() *Response { return &r.Response }
-
 // ExceptionInfoRequest: Retrieves the details of the exception that caused this event to be raised.
 // Clients should only call this request if the corresponding capability `supportsExceptionInfoRequest` is true.
 type ExceptionInfoRequest struct {
@@ -1523,8 +1335,6 @@ type ExceptionInfoRequest struct {
 
 	Arguments ExceptionInfoArguments `json:"arguments"`
 }
-
-func (r *ExceptionInfoRequest) GetRequest() *Request { return &r.Request }
 
 // ExceptionInfoArguments: Arguments for `exceptionInfo` request.
 type ExceptionInfoArguments struct {
@@ -1545,8 +1355,6 @@ type ExceptionInfoResponseBody struct {
 	Details     *ExceptionDetails  `json:"details,omitempty"`
 }
 
-func (r *ExceptionInfoResponse) GetResponse() *Response { return &r.Response }
-
 // ReadMemoryRequest: Reads bytes from memory at the provided location.
 // Clients should only call this request if the corresponding capability `supportsReadMemoryRequest` is true.
 type ReadMemoryRequest struct {
@@ -1554,8 +1362,6 @@ type ReadMemoryRequest struct {
 
 	Arguments ReadMemoryArguments `json:"arguments"`
 }
-
-func (r *ReadMemoryRequest) GetRequest() *Request { return &r.Request }
 
 // ReadMemoryArguments: Arguments for `readMemory` request.
 type ReadMemoryArguments struct {
@@ -1577,8 +1383,6 @@ type ReadMemoryResponseBody struct {
 	Data            string `json:"data,omitempty"`
 }
 
-func (r *ReadMemoryResponse) GetResponse() *Response { return &r.Response }
-
 // WriteMemoryRequest: Writes bytes to memory at the provided location.
 // Clients should only call this request if the corresponding capability `supportsWriteMemoryRequest` is true.
 type WriteMemoryRequest struct {
@@ -1586,8 +1390,6 @@ type WriteMemoryRequest struct {
 
 	Arguments WriteMemoryArguments `json:"arguments"`
 }
-
-func (r *WriteMemoryRequest) GetRequest() *Request { return &r.Request }
 
 // WriteMemoryArguments: Arguments for `writeMemory` request.
 type WriteMemoryArguments struct {
@@ -1609,8 +1411,6 @@ type WriteMemoryResponseBody struct {
 	BytesWritten int `json:"bytesWritten,omitempty"`
 }
 
-func (r *WriteMemoryResponse) GetResponse() *Response { return &r.Response }
-
 // DisassembleRequest: Disassembles code stored at the provided location.
 // Clients should only call this request if the corresponding capability `supportsDisassembleRequest` is true.
 type DisassembleRequest struct {
@@ -1618,8 +1418,6 @@ type DisassembleRequest struct {
 
 	Arguments DisassembleArguments `json:"arguments"`
 }
-
-func (r *DisassembleRequest) GetRequest() *Request { return &r.Request }
 
 // DisassembleArguments: Arguments for `disassemble` request.
 type DisassembleArguments struct {
@@ -1640,8 +1438,6 @@ type DisassembleResponse struct {
 type DisassembleResponseBody struct {
 	Instructions []DisassembledInstruction `json:"instructions"`
 }
-
-func (r *DisassembleResponse) GetResponse() *Response { return &r.Response }
 
 // Capabilities: Information about the capabilities of a debug adapter.
 type Capabilities struct {


### PR DESCRIPTION
This makes it easier to implement the
ResponseMessage/RequestMessage/EventMessage interface, because you only need to embed Response/Request/Message, respectively.