### PR TITLE
Use json.RawMessage when polymorphic fields contain submessages

### DIFF
--- a/cmd/gentypes/gentypes.go
+++ b/cmd/gentypes/gentypes.go
@@ -124,10 +124,22 @@ func parsePropertyType(propValue map[string]interface{}) string {
 		}
 
 	case []interface{}:
+		// This field is polymorphic so it needs a generic type.
+		for _, p := range propType.([]interface{}) {
+			s, ok := p.(string)
+			if !ok {
+				log.Fatalf("property type contains a non-string: %v", propType)
+			}
+			if s == "object" || s == "array" {
+				// It contains non-fundamental types, so treat it as opaque.
+				return "json.RawMessage"
+			}
+		}
+		// The possible types are all fundamental types, so we can use interface{}.
 		return "interface{}"
 
 	default:
-		log.Fatal("unknown property type", propType)
+		log.Fatalf("unknown property type %v", propType)
 	}
 
 	panic("unreachable")

--- a/cmd/gentypes/gentypes.go
+++ b/cmd/gentypes/gentypes.go
@@ -81,9 +81,9 @@ func parsePropertyType(propValue map[string]interface{}) string {
 		log.Fatal("property with no type or ref:", propValue)
 	}
 
-	switch propType.(type) {
+	switch typ := propType.(type) {
 	case string:
-		switch propType {
+		switch typ {
 		case "string":
 			return "string"
 		case "number":
@@ -125,10 +125,10 @@ func parsePropertyType(propValue map[string]interface{}) string {
 
 	case []interface{}:
 		// This field is polymorphic so it needs a generic type.
-		for _, p := range propType.([]interface{}) {
-			s, ok := p.(string)
+		for _, el := range typ {
+			s, ok := el.(string)
 			if !ok {
-				log.Fatalf("property type contains a non-string: %v", propType)
+				log.Fatalf("property type contains a non-string of type %T: %#v", el, typ)
 			}
 			if s == "object" || s == "array" {
 				// It contains non-fundamental types, so treat it as opaque.
@@ -139,7 +139,7 @@ func parsePropertyType(propValue map[string]interface{}) string {
 		return "interface{}"
 
 	default:
-		log.Fatalf("unknown property type %v", propType)
+		log.Fatalf("unknown property type %T (%#v)", typ, typ)
 	}
 
 	panic("unreachable")

--- a/codec_test.go
+++ b/codec_test.go
@@ -791,7 +791,7 @@ var exitedEventStruct = ExitedEvent{
 var terminatedEventString = `{"seq":5,"type":"event","event":"terminated","body":{"restart":true}}`
 var terminatedEventStruct = TerminatedEvent{
 	Event: *newEvent(5, "terminated"),
-	Body:  TerminatedEventBody{Restart: true},
+	Body:  TerminatedEventBody{Restart: json.RawMessage(`true`)},
 }
 
 var threadEventString = `{"seq":6,"type":"event","event":"thread","body":{"reason":"started","threadId":18}}`

--- a/schematypes.go
+++ b/schematypes.go
@@ -201,7 +201,7 @@ type TerminatedEvent struct {
 }
 
 type TerminatedEventBody struct {
-	Restart interface{} `json:"restart,omitempty"`
+	Restart json.RawMessage `json:"restart,omitempty"`
 }
 
 // ThreadEvent: The event indicates that a thread has started or exited.
@@ -224,14 +224,14 @@ type OutputEvent struct {
 }
 
 type OutputEventBody struct {
-	Category           string      `json:"category,omitempty"`
-	Output             string      `json:"output"`
-	Group              string      `json:"group,omitempty"`
-	VariablesReference int         `json:"variablesReference,omitempty"`
-	Source             *Source     `json:"source,omitempty"`
-	Line               int         `json:"line,omitempty"`
-	Column             int         `json:"column,omitempty"`
-	Data               interface{} `json:"data,omitempty"`
+	Category           string          `json:"category,omitempty"`
+	Output             string          `json:"output"`
+	Group              string          `json:"group,omitempty"`
+	VariablesReference int             `json:"variablesReference,omitempty"`
+	Source             *Source         `json:"source,omitempty"`
+	Line               int             `json:"line,omitempty"`
+	Column             int             `json:"column,omitempty"`
+	Data               json.RawMessage `json:"data,omitempty"`
 }
 
 // BreakpointEvent: The event indicates that some information about a breakpoint has changed.
@@ -1549,14 +1549,14 @@ type Thread struct {
 // Source: A `Source` is a descriptor for source code.
 // It is returned from the debug adapter as part of a `StackFrame` and it is used by clients when specifying breakpoints.
 type Source struct {
-	Name             string      `json:"name,omitempty"`
-	Path             string      `json:"path,omitempty"`
-	SourceReference  int         `json:"sourceReference,omitempty"`
-	PresentationHint string      `json:"presentationHint,omitempty"`
-	Origin           string      `json:"origin,omitempty"`
-	Sources          []Source    `json:"sources,omitempty"`
-	AdapterData      interface{} `json:"adapterData,omitempty"`
-	Checksums        []Checksum  `json:"checksums,omitempty"`
+	Name             string          `json:"name,omitempty"`
+	Path             string          `json:"path,omitempty"`
+	SourceReference  int             `json:"sourceReference,omitempty"`
+	PresentationHint string          `json:"presentationHint,omitempty"`
+	Origin           string          `json:"origin,omitempty"`
+	Sources          []Source        `json:"sources,omitempty"`
+	AdapterData      json.RawMessage `json:"adapterData,omitempty"`
+	Checksums        []Checksum      `json:"checksums,omitempty"`
 }
 
 // StackFrame: A Stackframe contains the source location.


### PR DESCRIPTION
So far, these fields were represented as `interface{}`, which means that the JSON library parsed these fields. However, they contain opaque data, which makes it very inconvenient to work with such a message. Now, fields with a submessage are represented as json.RawMessage, so that applications can re-parse these submessages into the correct structure more easily.

If the list of types only contains fundamental types, we stick with `interface{}`.