### PR TITLE
Treat RestartRequest arguments identical to Launch/Attach arguments

### DIFF
--- a/cmd/gentypes/gentypes.go
+++ b/cmd/gentypes/gentypes.go
@@ -297,7 +297,7 @@ func emitToplevelType(typeName string, descJson json.RawMessage, goTypeIsStruct 
 			} else {
 				fmt.Fprintf(&b, "\t%s %s `json:\"body,omitempty\"`\n", "Body", bodyTypeName)
 			}
-		} else if propName == "arguments" && (typeName == "LaunchRequest" || typeName == "AttachRequest") {
+		} else if propName == "arguments" && (typeName == "LaunchRequest" || typeName == "AttachRequest" || typeName == "RestartRequest") {
 			// Special case for LaunchRequest or AttachRequest arguments, which are implementation
 			// defined and don't have pre-set field names in the specification.
 			fmt.Fprintln(&b, "\tArguments json.RawMessage `json:\"arguments\"`")
@@ -563,6 +563,7 @@ var typesExcludeList = map[string]bool{
 	// Therefore, this type is not used anywhere.
 	"LaunchRequestArguments": true,
 	"AttachRequestArguments": true,
+	"RestartArguments":       true,
 }
 
 func main() {

--- a/schematypes.go
+++ b/schematypes.go
@@ -518,12 +518,7 @@ type AttachResponse struct {
 type RestartRequest struct {
 	Request
 
-	Arguments *RestartArguments `json:"arguments,omitempty"`
-}
-
-// RestartArguments: Arguments for `restart` request.
-type RestartArguments struct {
-	Arguments interface{} `json:"arguments,omitempty"`
+	Arguments json.RawMessage `json:"arguments"`
 }
 
 // RestartResponse: Response to `restart` request. This is just an acknowledgement, so no body field is required.


### PR DESCRIPTION
The restart request contains the last launch or attach arguments and should also be treated as an opaque embedded JSON message.