### PR TITLE
Use the `any` alias for `interface{}`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/google/go-dap
 
-go 1.13
+go 1.18
 
 retract v0.9.0

--- a/schematypes.go
+++ b/schematypes.go
@@ -388,12 +388,12 @@ type RunInTerminalRequest struct {
 
 // RunInTerminalRequestArguments: Arguments for `runInTerminal` request.
 type RunInTerminalRequestArguments struct {
-	Kind                        string                 `json:"kind,omitempty"`
-	Title                       string                 `json:"title,omitempty"`
-	Cwd                         string                 `json:"cwd"`
-	Args                        []string               `json:"args"`
-	Env                         map[string]interface{} `json:"env,omitempty"`
-	ArgsCanBeInterpretedByShell bool                   `json:"argsCanBeInterpretedByShell,omitempty"`
+	Kind                        string         `json:"kind,omitempty"`
+	Title                       string         `json:"title,omitempty"`
+	Cwd                         string         `json:"cwd"`
+	Args                        []string       `json:"args"`
+	Env                         map[string]any `json:"env,omitempty"`
+	ArgsCanBeInterpretedByShell bool           `json:"argsCanBeInterpretedByShell,omitempty"`
 }
 
 // RunInTerminalResponse: Response to `runInTerminal` request.
@@ -419,8 +419,8 @@ type StartDebuggingRequest struct {
 
 // StartDebuggingRequestArguments: Arguments for `startDebugging` request.
 type StartDebuggingRequestArguments struct {
-	Configuration map[string]interface{} `json:"configuration"`
-	Request       string                 `json:"request"`
+	Configuration map[string]any `json:"configuration"`
+	Request       string         `json:"request"`
 }
 
 // StartDebuggingResponse: Response to `startDebugging` request. This is just an acknowledgement, so no body field is required.
@@ -708,7 +708,7 @@ type DataBreakpointInfoResponse struct {
 }
 
 type DataBreakpointInfoResponseBody struct {
-	DataId      interface{}                `json:"dataId"`
+	DataId      any                        `json:"dataId"`
 	Description string                     `json:"description"`
 	AccessTypes []DataBreakpointAccessType `json:"accessTypes,omitempty"`
 	CanPersist  bool                       `json:"canPersist,omitempty"`
@@ -1506,16 +1506,16 @@ type ErrorMessage struct {
 //
 // To avoid an unnecessary proliferation of additional attributes with similar semantics but different names, we recommend to re-use attributes from the 'recommended' list below first, and only introduce new attributes if nothing appropriate could be found.
 type Module struct {
-	Id             interface{} `json:"id"`
-	Name           string      `json:"name"`
-	Path           string      `json:"path,omitempty"`
-	IsOptimized    bool        `json:"isOptimized,omitempty"`
-	IsUserCode     bool        `json:"isUserCode,omitempty"`
-	Version        string      `json:"version,omitempty"`
-	SymbolStatus   string      `json:"symbolStatus,omitempty"`
-	SymbolFilePath string      `json:"symbolFilePath,omitempty"`
-	DateTimeStamp  string      `json:"dateTimeStamp,omitempty"`
-	AddressRange   string      `json:"addressRange,omitempty"`
+	Id             any    `json:"id"`
+	Name           string `json:"name"`
+	Path           string `json:"path,omitempty"`
+	IsOptimized    bool   `json:"isOptimized,omitempty"`
+	IsUserCode     bool   `json:"isUserCode,omitempty"`
+	Version        string `json:"version,omitempty"`
+	SymbolStatus   string `json:"symbolStatus,omitempty"`
+	SymbolFilePath string `json:"symbolFilePath,omitempty"`
+	DateTimeStamp  string `json:"dateTimeStamp,omitempty"`
+	AddressRange   string `json:"addressRange,omitempty"`
 }
 
 // ColumnDescriptor: A `ColumnDescriptor` specifies what module attribute to show in a column of the modules view, how to format it,
@@ -1556,17 +1556,17 @@ type Source struct {
 
 // StackFrame: A Stackframe contains the source location.
 type StackFrame struct {
-	Id                          int         `json:"id"`
-	Name                        string      `json:"name"`
-	Source                      *Source     `json:"source,omitempty"`
-	Line                        int         `json:"line"`
-	Column                      int         `json:"column"`
-	EndLine                     int         `json:"endLine,omitempty"`
-	EndColumn                   int         `json:"endColumn,omitempty"`
-	CanRestart                  bool        `json:"canRestart,omitempty"`
-	InstructionPointerReference string      `json:"instructionPointerReference,omitempty"`
-	ModuleId                    interface{} `json:"moduleId,omitempty"`
-	PresentationHint            string      `json:"presentationHint,omitempty"`
+	Id                          int     `json:"id"`
+	Name                        string  `json:"name"`
+	Source                      *Source `json:"source,omitempty"`
+	Line                        int     `json:"line"`
+	Column                      int     `json:"column"`
+	EndLine                     int     `json:"endLine,omitempty"`
+	EndColumn                   int     `json:"endColumn,omitempty"`
+	CanRestart                  bool    `json:"canRestart,omitempty"`
+	InstructionPointerReference string  `json:"instructionPointerReference,omitempty"`
+	ModuleId                    any     `json:"moduleId,omitempty"`
+	PresentationHint            string  `json:"presentationHint,omitempty"`
 }
 
 // Scope: A `Scope` is a named container for variables. Optionally a scope can map to a source or a range within a source.


### PR DESCRIPTION
This alias was added in go 1.18, which has been out for a while already.

As `strings.Title()` is deprecated this PR also implements `goFieldName()` with a hand-rolled implementation which handles unicode correctly.