### PR TITLE
.github: update go version in test

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go-version: [1.20.x]
+        go-version: [1.23.x]
         include:
-          - go-version: 1.19.x
+          - go-version: 1.22.x
             os: ubuntu-latest
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
```
go install honnef.co/go/tools/cmd/staticcheck@latest
```

failed for go 1.19. 