### PR TITLE
cmd/gentypes: sync with canonical DAP v1.71.0 schema

### DIFF
--- a/cmd/gentypes/README.md
+++ b/cmd/gentypes/README.md
@@ -1,14 +1,11 @@
 The schema for DAP messages is defined in JSON at
-https://github.com/microsoft/vscode-debugadapter-node/blob/main/debugProtocol.json
-
-The auto-generated TypeScript representation of the schema is at
-https://github.com/microsoft/vscode-debugadapter-node/blob/main/protocol/src/debugProtocol.ts
+https://github.com/microsoft/debug-adapter-protocol/blob/main/debugAdapterProtocol.json
 
 ----
 
 In this directory we have a copy of the schema, which is licensed by Microsoft
 with a [MIT
-License](https://github.com/microsoft/vscode-debugadapter-node/blob/main/License.txt).
+License](https://github.com/microsoft/debug-adapter-protocol/blob/main/License-code.txt).
 This copy must be updated whenever the schema changes.
 
 To generate Go types from the schema, run:

--- a/cmd/gentypes/debugProtocol.json
+++ b/cmd/gentypes/debugProtocol.json
@@ -848,6 +848,11 @@
 					"additionalProperties": true,
 					"description": "Arguments passed to the new debug session. The arguments must only contain properties understood by the `launch` or `attach` requests of the debug adapter and they must not contain any client-specific properties (e.g. `type`) or client-specific features (e.g. substitutable 'variables')."
 				},
+				"outputPresentation": {
+					"type": "string",
+					"enum": ["separate", "mergeWithParent"],
+					"description": "Hints whether output of the child sessions should be presented separately or merged with that of the parent session's."
+				},
 				"request": {
 					"type": "string",
 					"enum": [

--- a/cmd/gentypes/gentypes.go
+++ b/cmd/gentypes/gentypes.go
@@ -690,7 +690,7 @@ func main() {
 }
 
 func updateInput(inputFilename string) error {
-	resp, err := http.Get("https://raw.githubusercontent.com/microsoft/vscode-debugadapter-node/main/debugProtocol.json")
+	resp, err := http.Get("https://raw.githubusercontent.com/microsoft/debug-adapter-protocol/main/debugAdapterProtocol.json")
 	if err != nil {
 		return err
 	}

--- a/doc.go
+++ b/doc.go
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 // Package dap contains data types and code for Debug Adapter Protocol (DAP) specification.
-// https://github.com/microsoft/vscode-debugadapter-node/blob/main/debugProtocol.json
+// https://github.com/microsoft/debug-adapter-protocol/blob/main/debugAdapterProtocol.json
 package dap
 
 //go:generate go run ./cmd/gentypes/gentypes.go -o schematypes.go -u cmd/gentypes/debugProtocol.json
-

--- a/schematypes.go
+++ b/schematypes.go
@@ -421,8 +421,9 @@ type StartDebuggingRequest struct {
 
 // StartDebuggingRequestArguments: Arguments for `startDebugging` request.
 type StartDebuggingRequestArguments struct {
-	Configuration map[string]any `json:"configuration"`
-	Request       string         `json:"request"`
+	Configuration      map[string]any `json:"configuration"`
+	OutputPresentation string         `json:"outputPresentation,omitempty"`
+	Request            string         `json:"request"`
 }
 
 // StartDebuggingResponse: Response to `startDebugging` request. This is just an acknowledgement, so no body field is required.


### PR DESCRIPTION
Changes:

1. Switch schema source URL in `cmd/gentypes/gentypes.go` — the DAP schema's canonical home is `microsoft/debug-adapter-protocol/main/debugAdapterProtocol.json`. The previous URL (`microsoft/vscode-debugadapter-node/main/debugProtocol.json`) is a downstream mirror synced for npm publishing. See Microsoft's own [pipeline documentation](https://github.com/microsoft/debug-adapter-protocol/blob/main/contributing.md#releasing-dap-changes).

2. Add `outputPresentation` to `StartDebuggingRequestArguments` — the field is present in the canonical 1.71.0 schema but absent from the downstream mirror.

3. Copy edit — Clean up comment in `cmd/gentypes/gentypes.go` and revise `cmd/gentypes/README.md` (URL correction, license link, drop stale TS reference).

Fixes #98